### PR TITLE
Only unpack the first two OpenGL version numbers

### DIFF
--- a/glumpy/app/configuration.py
+++ b/glumpy/app/configuration.py
@@ -308,7 +308,7 @@ def gl_get_configuration():
     # Dumb parsing of the GL_VERSION string
     version = gl.glGetString(gl.GL_VERSION)
     version = version.split(" ")[0]
-    major,minor = version.split('.')
+    major,minor = version.split('.')[:2]
     configuration._version = version
     configuration._major_version = int(major)
     configuration._minor_version = int(minor)


### PR DESCRIPTION
Under NVIDIA and linux the version number was 4.4.0 which does not
unpack.
