### PR TITLE
Fix error C2143 in sdf.c(619, 620) while compiling on windows 7 with msvs 2010 compiler.

### DIFF
--- a/glumpy/ext/freetype/__init__.py
+++ b/glumpy/ext/freetype/__init__.py
@@ -30,6 +30,16 @@ __dll__    = None
 __handle__ = None
 FT_Library_filename = ctypes.util.find_library('freetype')
 if not FT_Library_filename:
+    import platform
+    ft_versions = (str(v) for v in (255, 254, 253, 252, 251, 250,
+                                    2412, 2411, 2410, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+                                    2312, 2311, 2310, 239, 238, 237, 236, 235, 234, 233, 232, 231, 230,
+                                    221))  # versions of freetype2 to check
+    for v in ft_versions:
+        FT_Library_filename = ctypes.util.find_library('freetype' + ft_version)
+        if FT_Library_filename is not None:
+            break
+if not FT_Library_filename:
     try:
         __dll__ = ctypes.CDLL('libfreetype.so.6')
     except OSError:

--- a/glumpy/ext/sdf/sdf.c
+++ b/glumpy/ext/sdf/sdf.c
@@ -587,8 +587,7 @@ _compute_sdf( double *data, unsigned int width, unsigned int height)
     double * outside = (double *) calloc( width * height, sizeof(double) );
     double * inside  = (double *) calloc( width * height, sizeof(double) );
     unsigned int i;
-    double vmin;
-    double vmax;
+    double vmin, vmax, v;
     
     // Compute outside = edtaa3(bitmap); % Transform background (0's)
     computegradient( data, height, width, gx, gy);
@@ -633,7 +632,7 @@ _compute_sdf( double *data, unsigned int width, unsigned int height)
 
     for( i=0; i<width*height; ++i)
     {
-        double v = outside[i];
+        v = outside[i];
         if     ( v < vmin) outside[i] = vmin;
         else if( v > vmax) outside[i] = vmax;
         //data[i] = (outside[i]+vmin)/(2*vmin);

--- a/glumpy/ext/sdf/sdf.c
+++ b/glumpy/ext/sdf/sdf.c
@@ -586,8 +586,10 @@ _compute_sdf( double *data, unsigned int width, unsigned int height)
     double * gy      = (double *) calloc( width * height, sizeof(double) );
     double * outside = (double *) calloc( width * height, sizeof(double) );
     double * inside  = (double *) calloc( width * height, sizeof(double) );
-    int i;
-
+    unsigned int i;
+    double vmin;
+    double vmax;
+    
     // Compute outside = edtaa3(bitmap); % Transform background (0's)
     computegradient( data, height, width, gx, gy);
     edtaa3(data, gx, gy, width, height, xdist, ydist, outside);
@@ -616,8 +618,8 @@ _compute_sdf( double *data, unsigned int width, unsigned int height)
 
     // distmap = outside - inside; % Bipolar distance field
 
-    float vmin = outside[0];
-    float vmax = outside[0];
+    vmin = outside[0];
+    vmax = outside[0];
     for( i=0; i<width*height; ++i)
     {
         outside[i] -= inside[i];
@@ -631,7 +633,7 @@ _compute_sdf( double *data, unsigned int width, unsigned int height)
 
     for( i=0; i<width*height; ++i)
     {
-        float v = outside[i];
+        double v = outside[i];
         if     ( v < vmin) outside[i] = vmin;
         else if( v > vmax) outside[i] = vmax;
         //data[i] = (outside[i]+vmin)/(2*vmin);


### PR DESCRIPTION
<fix>
Fix error C2143 in sdf.c(619, 620) while compiling on windows 7 with msvs 2010 compiler.
In a C program, variables must be declared at the beginning of the function, and they cannot be declared after the function executes non-declaration instructions.
"https://msdn.microsoft.com/ru-ru/library/0afb82ta.aspx"
</fix>