### PR TITLE
Add the ability to write movies from within python

### DIFF
--- a/examples/movie-writer.py
+++ b/examples/movie-writer.py
@@ -7,7 +7,7 @@
 import numpy as np
 from glumpy import app, gl, glm, gloo, data
 from glumpy.geometry import primitives
-from glumpy.ext.ffmpeg_writer import FFMPEG_VideoWriter
+from glumpy.app.movie import record
 
 
 vertex = """
@@ -35,30 +35,14 @@ void main()
 
 width, height = 512,512
 window = app.Window(width, height, color=(0.30, 0.30, 0.35, 1.00))
-duration = 5.0
-framerate = 60
-writer = FFMPEG_VideoWriter("cube.mp4", (width, height), fps=framerate)
-fbuffer = np.zeros((window.height, window.height, 3), dtype=np.uint8)
-
 
 @window.event
 def on_draw(dt):
-    global phi, theta, writer, duration
+    global phi, theta
 
     window.clear()
     gl.glEnable(gl.GL_DEPTH_TEST)
     cube.draw(gl.GL_TRIANGLES, faces)
-
-    # Write one frame
-    if writer is not None:
-        if duration > 0:
-            gl.glReadPixels(0, 0, window.width, window.height,
-                            gl.GL_RGB, gl.GL_UNSIGNED_BYTE, fbuffer)
-            writer.write_frame(fbuffer)
-            duration -= dt
-        else:
-            writer.close()
-            writer = None
 
     # Make cube rotate
     theta += 0.5 # degrees
@@ -84,4 +68,7 @@ cube['model'] = np.eye(4, dtype=np.float32)
 cube['texture'] = data.checkerboard()
 phi, theta = 0, 0
 
-app.run(framerate=framerate)
+duration = 5.0
+framerate = 60
+with record(window, "cube.mp4", fps=framerate):
+    app.run(framerate=framerate, duration=duration)

--- a/glumpy/app/movie.py
+++ b/glumpy/app/movie.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015, Dzhelil S. Rufat
+# Distributed under the (new) BSD License. See LICENSE.txt for more info.
+# -----------------------------------------------------------------------------
+"""
+A module for reading and writing movies.
+"""
+import contextlib
+import numpy as np
+
+from glumpy import gl
+from glumpy.ext.ffmpeg_writer import FFMPEG_VideoWriter
+
+
+@contextlib.contextmanager
+def record(window, filename, fps):
+    '''
+    Record an animated window to a movie file.
+
+    :param window: window that is being recorded.
+    :param filename: name of the file to write the movie to.
+    :param fps: framerate at which to record.
+    '''
+
+    writer = FFMPEG_VideoWriter(filename, (window.width, window.height), fps=fps)
+    fbuffer = np.zeros((window.height, window.width, 3), dtype=np.uint8)
+
+    # Function to write one frame
+    def write_frame(writer):
+        gl.glReadPixels(0, 0, window.width, window.height,
+                        gl.GL_RGB, gl.GL_UNSIGNED_BYTE, fbuffer)
+        writer.write_frame(np.flipud(fbuffer))
+
+    # Modify the on_draw event handler to also write a
+    # movie frame every time it is called
+    old_on_draw = window.get_handler('on_draw')
+    @window.event
+    def on_draw(dt):
+        old_on_draw(dt)
+        write_frame(writer)
+
+    yield
+
+    writer.close()

--- a/glumpy/app/window/event.py
+++ b/glumpy/app/window/event.py
@@ -329,6 +329,25 @@ class EventDispatcher(object):
             except KeyError:
                 pass
 
+    def get_handler(self, name):
+        '''Get a single event handler by name.
+
+        Returns the first handler function that matches name.
+
+	Raises KeyError if name is not found.
+
+        :param string name:
+             Name of the event type to get.
+
+        '''
+        for frame in self._event_stack:
+            try:
+                return frame[name]
+            except KeyError:
+                pass
+
+        raise KeyError('Event handler {} not found.'.format(name))
+
     def dispatch_event(self, event_type, *args):
         '''Dispatch a single event to the attached handlers.
 


### PR DESCRIPTION
Add the ability to write movies from within python (in addition to the existing functionality of doing it from the command line using --record).
    
Any glumpy file can be recorded and converted into a movie file by simply modifying

 ```python 
app.run()
 ```
to

 ```python     
with recorder(window, 'movie.mp4', fps=60):
    app.run()
 ```
    
Nothing else needs to be touched. The on_draw function gets modified automatically to record a frame every time it is called.
    
See `examples/movie-writer.py` for a working example.

The --record option to the command line works as before.