### PR TITLE
Rather than using the generic name 'movie.mp4' name the file based on

### DIFF
--- a/glumpy/app/__init__.py
+++ b/glumpy/app/__init__.py
@@ -329,7 +329,10 @@ def run(clock=None, framerate=None, interactive=None,
 
         if options.record:
             from .movie import record
-            filename='movie.mp4'
+            # Obtain the name of the script that is being run
+            name = os.path.basename(sys.argv[0])
+            # Replace .py extension with .mp4
+            filename=re.sub('.py$', '.mp4', name)
             log.info("Recording movie in '%s'" % filename)
             with record(window=__backend__.windows()[0],
                         filename=filename,


### PR DESCRIPTION
the name ofthe script that is being run. For example running

$ python protein.py --record

would result in the movie file being saved to a file

protein.mp4