### PR TITLE
Avoid using using double underscore to prefix preprocessor names (rebased).

### DIFF
--- a/glumpy/library/transforms/geo-position-struct.glsl
+++ b/glumpy/library/transforms/geo-position-struct.glsl
@@ -3,8 +3,8 @@
 // Distributed under the (new) BSD License.
 // -----------------------------------------------------------------------------
 
-#ifndef __GEO_POSITION_STRUCT__
-#define __GEO_POSITION_STRUCT__
+#ifndef _GLUMPY__GEO_POSITION_STRUCT__
+#define _GLUMPY__GEO_POSITION_STRUCT__
 struct GeoPosition
 {
     float longitude;


### PR DESCRIPTION
On some graphics cards this leads to an error:

-> error C0118: macros prefixed with '__' are reserved

...
024 #ifndef GEO_POSITION_STRUCT
025 #define GEO_POSITION_STRUCT
026 struct GeoPosition
027 {
028 float longitude;
...