### PR TITLE
Replace Texture2D with TextureFloat2D

### DIFF
--- a/examples/float-texture.py
+++ b/examples/float-texture.py
@@ -41,6 +41,6 @@ program = gloo.Program(vertex, fragment, count=4)
 program['position'] = [(-1,-1), (-1,+1), (+1,-1), (+1,+1)]
 program['texcoord'] = [( 0, 1), ( 0, 0), ( 1, 1), ( 1, 0)]
 T = np.linspace(0/256.0, 1/256.0, 32*32)
-program['texture'] = T.astype(np.float32).reshape(32,32)
+program['texture'] = T.astype(np.float32).reshape(32,32).view(gloo.TextureFloat2D)
 
 app.run()

--- a/glumpy/graphics/collections/base_collection.py
+++ b/glumpy/graphics/collections/base_collection.py
@@ -5,7 +5,7 @@
 import math
 import numpy as np
 from glumpy import gl
-from glumpy.gloo.texture import Texture2D
+from glumpy.gloo.texture import TextureFloat2D
 from glumpy.gloo.buffer import VertexBuffer, IndexBuffer
 from . util import dtype_reduce
 from . array_list import ArrayList
@@ -515,7 +515,7 @@ class BaseCollection(object):
 
             # shape[2] = float count is only used in vertex shader code
             texture = texture.reshape(shape[0],shape[1],4)
-            self._uniforms_texture = texture.view(Texture2D)
+            self._uniforms_texture = texture.view(TextureFloat2D)
             self._uniforms_texture.interpolation = gl.GL_NEAREST
 
         if len(self._programs):


### PR DESCRIPTION
This makes the `font-agg.py`, `font-sdf.py`, `float-texture.py`  and `material-colors.py`  examples work correctly.

Fixes #31 and fixes #68 