### PR TITLE
Fix examples for python 3.5

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -104,12 +104,12 @@ directly relates to the `position` attribute within the vertex shader and the
 
 
 .. code:: python
-          
+
    quad['position'] = [(-0.5, -0.5),
                        (-0.5, +0.5),
                        (+0.5, -0.5),
                        (+0.5, +0.5)]
-   quad['color'] = 0,0,0,1
+   quad['color'] = 1,0,0,1  # red
 
 Last, we specify in the :meth:`~glumpy.app.Window.on_draw` method that the quad
 needs to be rendered using :const:`gl.GL_TRIANGLE_STRIP`.
@@ -138,12 +138,14 @@ and adapt quad coordinates according to the sine of the time variable.
 
    vertex = """
             uniform float time;
-            vec2 attribute position;
+            attribute vec2 position;
             void main()
             {
                 vec2 xy = vec2(sin(2.0*time));
                 gl_Position = vec4(position*(0.25 + 0.75*xy*xy), 0.0, 1.0);
             } """
+
+   quad = gloo.Program(vertex, fragment, count=4)
 
 We also need to initialize the time variable and to update it at each draw
 call.

--- a/examples/app-two-programs.py
+++ b/examples/app-two-programs.py
@@ -27,9 +27,9 @@ void main() {
 """
 
 
-program1 = gloo.Program(vertex, fragment1)  # blue on the left
+program1 = gloo.Program(vertex, fragment1)  # blue on the right
 program1['a_position'] = np.zeros((1,2),dtype=np.float32) + 0.5
-program2 = gloo.Program(vertex, fragment2)  # red on the right
+program2 = gloo.Program(vertex, fragment2)  # red on the left
 program2['a_position'] = np.zeros((1,2),dtype=np.float32) - 0.5
 
 

--- a/examples/gloo-irregular-grids.py
+++ b/examples/gloo-irregular-grids.py
@@ -59,7 +59,7 @@ def compute_grid():
     stop  = xmax - math.fmod(xmax, t1)
     if abs(stop-xmax) < epsilon: stop -= t1
     count = (stop-start)/t1+1
-    I = np.zeros(count+2)
+    I = np.zeros(int(count+2))
     I[0], I[-1] = xmin, xmax
     I[1:-1] = np.linspace(start, stop, count, endpoint=True)
     Z[..., 0] = I[find_closest_direct(I, start=xmin, end=xmax, count=n)]
@@ -70,7 +70,7 @@ def compute_grid():
     stop  = xmax - math.fmod(xmax, t2)
     if abs(stop-xmax) < epsilon: stop -= t2
     count = (stop-start)/t2+1
-    I = np.zeros(count+2)
+    I = np.zeros(int(count+2))
     I[0], I[-1] = xmin, xmax
     I[1:-1] = np.linspace(start, stop, count, endpoint=True)
     Z[..., 1] = I[find_closest_direct(I, start=xmin, end=xmax, count=n)]
@@ -83,7 +83,7 @@ def compute_grid():
     stop  = ymax - math.fmod(ymax, t1)
     if abs(stop-ymax) < epsilon: stop -= t1
     count = (stop-start)/t1+1
-    I = np.zeros(count+2)
+    I = np.zeros(int(count+2))
     I[0], I[-1] = ymin, ymax
     I[1:-1] = np.linspace(start, stop, count, endpoint=True)
     Z[..., 2] = I[find_closest_direct(I, start=ymin, end=ymax, count=n)]
@@ -94,7 +94,7 @@ def compute_grid():
     stop  = ymax - math.fmod(ymax, t2)
     if abs(stop-ymax) < epsilon: stop -= t2
     count = (stop-start)/t2+1
-    I = np.zeros(count+2)
+    I = np.zeros(int(count+2))
     I[0], I[-1] = ymin, ymax
     I[1:-1] = np.linspace(start, stop, count, endpoint=True)
     Z[..., 3] = I[find_closest_direct(I, start=ymin, end=ymax, count=n)]

--- a/examples/grayscott.py
+++ b/examples/grayscott.py
@@ -159,8 +159,8 @@ P[:, :] = species['Coral']
 UV = np.zeros((h, w, 4), dtype=np.float32)
 UV[:, :, 0] = 1.0
 r = 32
-UV[h/2-r:h/2+r,w/2-r:w/2+r,0] = 0.50
-UV[h/2-r:h/2+r,w/2-r:w/2+r,1] = 0.25
+UV[h//2-r:h//2+r,w//2-r:w//2+r,0] = 0.50
+UV[h//2-r:h//2+r,w//2-r:w//2+r,1] = 0.25
 UV += np.random.uniform(0.00, 0.01, (h, w, 4))
 UV[:,:,2] = UV[:,:,0]
 UV[:,:,3] = UV[:,:,1]

--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -2,16 +2,25 @@
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.
 # -----------------------------------------------------------------------------
-from glumpy import app, gl, gloo, glm, data, text
+from glumpy import app, gl, gloo, glm, data
+from glumpy.graphics.text import FontManager
+from glumpy.graphics.collections import GlyphCollection
+from glumpy.transforms import Position, OrthographicProjection
 
 window = app.Window(width=512, height=512)
 
 @window.event
 def on_draw(dt):
     window.clear()
-    label.draw(x=256, y=256, color=(1,1,1,1))
+    label.draw()
 
-font = text.TextureFont(data.get("OpenSans-Regular.ttf"), 64)
-label = text.Label("Hello World !", font,
-                   anchor_x = 'center', anchor_y = 'center')
+x,y,z = 256,256,0
+font = FontManager.get("OpenSans-Regular.ttf", 64, mode='agg')
+label = GlyphCollection('agg', transform=OrthographicProjection(Position()))
+label.append("Hello World !", font,
+                   anchor_x = 'center', anchor_y = 'center',
+                   origin=(x,y,z), color=(1,1,1,1))
+
+window.attach(label["transform"])
+
 app.run()

--- a/examples/interpolations.py
+++ b/examples/interpolations.py
@@ -106,7 +106,7 @@ vertices['interpol'] = np.arange(17).reshape(17,1)
 program.bind(vertices)
 indices = np.zeros((17,6),np.uint32).view(gloo.IndexBuffer)
 indices[:] = [0,1,2,1,2,3]
-indices += 4*np.arange(17).reshape(17,1)
+indices += 4*np.arange(17,dtype=np.uint32).reshape(17,1)
 
 lena = data.get("lena.png")
 program['u_data'] = lena

--- a/glumpy/app/__init__.py
+++ b/glumpy/app/__init__.py
@@ -335,8 +335,12 @@ def run(clock=None, framerate=None, interactive=None,
 
         if options.record:
             from .movie import record
-            # Obtain the name of the script that is being run
-            name = os.path.basename(sys.argv[0])
+            try:
+                # Check if output file name given
+                name = sys.argv[2]
+            except:
+                # Obtain the name of the script that is being run
+                name = os.path.basename(sys.argv[0])
             # Replace .py extension with .mp4
             filename=re.sub('.py$', '.mp4', name)
             log.info("Recording movie in '%s'" % filename)

--- a/glumpy/geometry/normals.py
+++ b/glumpy/geometry/normals.py
@@ -40,7 +40,7 @@ def compact(vertices, indices, tolerance=1e-3):
     I_ = indices.copy().ravel()
     for i in range(len(indices)):
         I_[i] = RI[indices[i]]
-    I_ = I_.reshape(len(indices)/3,3)
+    I_ = I_.reshape(len(indices)//3,3)
 
     # Return reduced vertices set, transalted indices and mapping that allows
     # to go from U to V

--- a/glumpy/geometry/parametric.py
+++ b/glumpy/geometry/parametric.py
@@ -52,6 +52,6 @@ def surface(func, umin=0, umax=2*np.pi, ucount=64, urepeat=1.0,
             indices.append(i*(vcount) + j        )
     indices = np.array(indices, dtype=itype)
     vertices["normal"] = normals(vertices["position"],
-                                 indices.reshape(len(indices)/3,3))
+                                 indices.reshape(len(indices)//3,3))
 
     return vertices.view(gloo.VertexBuffer), indices.view(gloo.IndexBuffer)

--- a/glumpy/gloo/gpudata.py
+++ b/glumpy/gloo/gpudata.py
@@ -140,7 +140,7 @@ class GPUData(np.ndarray):
         return self.__getitem__(slice(start, stop))
 
     def __setslice__(self, start, stop,  value):
-        return self.__setitem__(slice(start, stop), value)
+        return self.__setitem__(slice(int(start), int(stop)), value)
 
     def __iadd__(self, other):
         self._add_pending_data(self._extents[0], self._extents[1])

--- a/glumpy/graphics/collections/agg_fast_path_collection.py
+++ b/glumpy/graphics/collections/agg_fast_path_collection.py
@@ -166,7 +166,7 @@ class AggFastPathCollection(Collection):
         V[:,-1] = V[:,-2]
         V = V.ravel()
         V = np.repeat(V,2,axis=0)
-        V['id'] = np.tile([1,-1],len(V)/2)
+        V['id'] = np.tile([1,-1],len(V)//2)
         if closed:
             V = V.reshape(itemcount,2*(itemsize+3))
         else:

--- a/glumpy/graphics/collections/base_collection.py
+++ b/glumpy/graphics/collections/base_collection.py
@@ -489,7 +489,7 @@ class BaseCollection(object):
             shape = self._compute_texture_shape(size)
 
             # shape[2] = float count is only used in vertex shader code
-            texture = texture.reshape(shape[0], shape[1], 4)
+            texture = texture.reshape(int(shape[0]), int(shape[1]), 4)
             self._uniforms_texture = texture.view(TextureFloat2D)
             self._uniforms_texture.interpolation = gl.GL_NEAREST
 

--- a/glumpy/graphics/text/agg_font.py
+++ b/glumpy/graphics/text/agg_font.py
@@ -68,7 +68,7 @@ class AggFont(object):
             rows   = face.glyph.bitmap.rows
             pitch  = face.glyph.bitmap.pitch
 
-            w = width/3
+            w = int(width/3)
             h = rows
             # h+1,w+1 to have a black border
             region = self.atlas.allocate( (h+1,w+1) )

--- a/glumpy/graphics/text/sdf_font.py
+++ b/glumpy/graphics/text/sdf_font.py
@@ -97,10 +97,10 @@ class SDFFont(object):
 
         # Pad high resolution glyph with a blank border and normalize values
         # between 0 and 1
-        hires_width  = (1+2*self._padding)*width
-        hires_height = (1+2*self._padding)*height
+        hires_width  = int((1+2*self._padding)*width)
+        hires_height = int((1+2*self._padding)*height)
         hires_data = np.zeros( (hires_height,hires_width), np.double)
-        ox,oy = self._padding*width, self._padding*height
+        ox,oy = int(self._padding*width), int(self._padding*height)
         hires_data[oy:oy+height, ox:ox+width] = G/255.0
 
        # Compute distance field at high resolution


### PR DESCRIPTION
This PR has some fixes needed to run some of the examples with Python 3.5.2.

Also has fixes to the hello-world example where the imports seemed to have been broken.

Also has some fixes to the quickstart to clarify commands.  For example, I could not see the square in https://github.com/mtpatter/glumpy/blob/master/doc/quickstart.rst#displaying-a-quad because the quad color was set to black.

Also since the quickstart says you can record animations with `--record filename`, added here a way to specify that filename output (instead of the default).

Thanks for this project- very nice visualizations.
