### PR TITLE
Make ice symmetric with respect to fire.

### DIFF
--- a/glumpy/library/colormaps/ice.glsl
+++ b/glumpy/library/colormaps/ice.glsl
@@ -6,7 +6,9 @@
 
 vec3 colormap_ice(float t)
 {
-   return vec3(t, t, 1.0);
+   t = 1 - t;
+   return mix(mix(vec3(1,1,1), vec3(0,1,1), t),
+               mix(vec3(0,1,1), vec3(0,0,1), t*t), t);
 }
 
 vec3 colormap_ice(float t, vec3 under, vec3 over)


### PR DESCRIPTION
Make the ice color scheme look symmetric with respect to the fire one. At the moment when you plot using the icefire color scheme they do not look symmetric to each other. With this fix, things look symmetric like below

![image](http://i.imgur.com/BRd7QVr.png)