### PR TITLE
fix print function not being in python2

### DIFF
--- a/glumpy/ext/png.py
+++ b/glumpy/ext/png.py
@@ -144,7 +144,7 @@ And now, my famous members
 
 # http://www.python.org/doc/2.2.3/whatsnew/node5.html
 from __future__ import generators
-
+from __future__ import print_function
 __version__ = "0.0.17"
 
 from array import array


### PR DESCRIPTION
the png extension would not bytecode compile for python2. This one line change fixes it.

the code in question wont get hit in normal library usage but it DOES get hit if you try and make an rpm or deb package, since they precompile everything