### PR TITLE
Define coding for non-ascii files without any.

### DIFF
--- a/examples/gloo-terminal.py
+++ b/examples/gloo-terminal.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_freeglut.py
+++ b/glumpy/app/window/backends/backend_freeglut.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_osxglut.py
+++ b/glumpy/app/window/backends/backend_osxglut.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_pyside.py
+++ b/glumpy/app/window/backends/backend_pyside.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_sdl.py
+++ b/glumpy/app/window/backends/backend_sdl.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/app/window/backends/backend_sdl2.py
+++ b/glumpy/app/window/backends/backend_sdl2.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.

--- a/glumpy/library/build-spatial-filters.py
+++ b/glumpy/library/build-spatial-filters.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
 # Distributed under the (new) BSD License.


### PR DESCRIPTION
This commit adds a file encoding specification to each non-ascii python file currently without one.

https://www.python.org/dev/peps/pep-0263/