### PR TITLE
Make geom-path example to work

### DIFF
--- a/glumpy/gloo/program.py
+++ b/glumpy/gloo/program.py
@@ -74,7 +74,7 @@ class Program(GLObject):
                 if not '{' in fragment:
                     fragment = library.get(fragment)
                 self._fragment = FragmentShader(fragment, version=version)
-            elif isinstance(fragment, FragmentShader, version=version):
+            elif isinstance(fragment, FragmentShader):
                 self._fragment = fragment
                 self._fragment._version = version
             else:


### PR DESCRIPTION
Currently, the example fails to execute.
Related https://github.com/glumpy/glumpy/issues/109

```
$ python geom-path.py                                                             
Traceback (most recent call last):
  File "geom-path.py", line 313, in <module>
    program = gloo.Program(vertex, fragment, geometry)
  File "/home/leus/playground/glumpy/glumpy/gloo/program.py", line 77, in __init__
    elif isinstance(fragment, FragmentShader, version=version):
TypeError: isinstance() takes no keyword arguments
```
