### PR TITLE
Change the default parameter value of GeometryShader

### DIFF
--- a/glumpy/gloo/shader.py
+++ b/glumpy/gloo/shader.py
@@ -400,7 +400,7 @@ class GeometryShader(Shader):
 
 
     def __init__(self, code=None,
-                 vertices_out=0, input_type=None, output_type=None, version="120"):
+                 vertices_out=None, input_type=None, output_type=None, version="120"):
         Shader.__init__(self, gl.GL_GEOMETRY_SHADER_EXT, code, version)
 
         self._vertices_out = vertices_out


### PR DESCRIPTION
I changed the `vertices_out` to take `None` by default so that it behaves nicely when working with modern GL with geometry sharers.

With the current default value `0`, the program calls `glProgramParameteriEXT`. This style is obsolete, and the geometry shader information is encoded in the shader itself nowadays with commands such as `layout` and `Emitvertex`. By default, this function should not be called.

Here is the link to the part of the code that gets affected by the value of `vertices_out`.

https://github.com/glumpy/glumpy/blob/master/glumpy/gloo/program.py#L231

Also, here is a simple example using a geometry shader.
https://gist.github.com/yuyu2172/5297d243d45610f7806255e1a26e537a