### PR TITLE
Call VertexAttribPointer properly when two VAOs are used

### DIFF
--- a/glumpy/gloo/variable.py
+++ b/glumpy/gloo/variable.py
@@ -382,6 +382,11 @@ class Attribute(Variable):
             gl.glVertexAttribPointer(self.handle, size, gtype, gl.GL_FALSE, stride, offset)
         elif isinstance(self.data,VertexArray):
             self.data.activate()
+            size, gtype, dtype = gl_typeinfo[self._gtype]
+            stride = self.data.stride
+            offset = ctypes.c_void_p(self.data.offset)
+            gl.glEnableVertexAttribArray(self.handle)
+            gl.glVertexAttribPointer(self.handle, size, gtype, gl.GL_FALSE, stride, offset)
 
     def _deactivate(self):
         if isinstance(self.data,VertexBuffer):

--- a/glumpy/gloo/variable.py
+++ b/glumpy/gloo/variable.py
@@ -373,14 +373,7 @@ class Attribute(Variable):
 
 
     def _activate(self):
-        if isinstance(self.data,VertexBuffer):
-            self.data.activate()
-            size, gtype, dtype = gl_typeinfo[self._gtype]
-            stride = self.data.stride
-            offset = ctypes.c_void_p(self.data.offset)
-            gl.glEnableVertexAttribArray(self.handle)
-            gl.glVertexAttribPointer(self.handle, size, gtype, gl.GL_FALSE, stride, offset)
-        elif isinstance(self.data,VertexArray):
+        if isinstance(self.data, (VertexBuffer, VertexArray)):
             self.data.activate()
             size, gtype, dtype = gl_typeinfo[self._gtype]
             stride = self.data.stride


### PR DESCRIPTION
Related to a discussion in #102.

This PR is necessary to make the example below to work (alternate between two colors).

```python
# modified examples/tutorial/quad-simple.py
from glumpy import app, gloo, gl
import numpy as np

vertex = """
  uniform float scale;
  attribute vec2 position;
  attribute vec4 color;
  varying vec4 v_color;
  void main()
  {
    gl_Position = vec4(scale*position, 0.0, 1.0);
    v_color = color;
  } """

fragment = """
  varying vec4 v_color;
  void main()
  {
      gl_FragColor = v_color;
  } """

app.use('glfw', api='GL', major=3, minor=3, profile='core')

# Create a window with a valid GL context
window = app.Window()

# Build the program and corresponding buffers (with 4 vertices)
quad = gloo.Program(vertex, fragment, count=4)
dtype = [('color', np.float32, 4),
         ('position', np.float32, 2)]
quad_arrays_0 = np.zeros(4, dtype).view(gloo.VertexArray)
# Four colors
quad_arrays_0['color'] = [ (1,0,0,1), (0,1,0,1), (0,0,1,1), (1,1,0,1) ]
quad_arrays_0['position'] = [ (-1,-1),   (-1,+1),   (+1,-1),   (+1,+1)   ]

quad_arrays_1 = np.zeros(4, dtype).view(gloo.VertexArray)
# All red data
quad_arrays_1['color'] = [ (1,0,0,1), (1,0,0,1), (1,0,0,1), (1,0,0,1) ]
quad_arrays_1['position'] = [ (-1,-1),   (-1,+1),   (+1,-1),   (+1,+1)   ]

quad['scale'] = 1.0


# Tell glumpy what needs to be done at each redraw
count = 0
@window.event
def on_draw(dt):
    global count
    window.clear()
    if count % 2 == 0:
        quad.bind(quad_arrays_0)
        quad.draw(gl.GL_TRIANGLE_STRIP)
    else:
        quad.bind(quad_arrays_1)
        quad.draw(gl.GL_TRIANGLE_STRIP)
    count += 1

# Run the app
app.run(framerate=1)
```

The visualization works as expected for the first VAO, but fails to do so for the second one because `glVertexAttribPointer` is not called for it.

I will explain the code above.
`quad.bind` overrides the VAO that the attributes (`color` and `position`) point to.
Inside the `quad.draw`, VAOs and VBOs are actually created and linked to the vertex shader.
In order to achieve the desired behavior, `glBindVertexArray`, `glBindBuffer`, ` glBufferData` and `glVertexAttribPointer` need to be called in this order.
I checked, and the commands other than the last are called properly.
However, `glVertexAttribPointer` is not called when the second VAO is binded.

`glVertexAttribPointer` can be called in `Attribute._update` (https://github.com/glumpy/glumpy/blob/master/glumpy/gloo/variable.py#L426).
This method is not called when the second VAO is binded because the `_need_update` attribute of the `Attribute` is False at that time.

This PR fixes this problem by calling `glVetexAttribPointer` in `activate` in the same way `VertexBuffer` does.
