### PR TITLE
Support TextureInteger* together with Uniforms

### DIFF
--- a/examples/integer-texture.py
+++ b/examples/integer-texture.py
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
+# Distributed under the (new) BSD License.
+# -----------------------------------------------------------------------------
+# This example is used to check if int texture are working (depending on GPU):
+# Only one color on screen: texture int are not working
+# Several colors on screen: texture int are working
+# -----------------------------------------------------------------------------
+import numpy as np
+from glumpy import app, gloo, gl
+
+vertex = """
+    in vec2 position;
+    in vec2 texcoord;
+    out vec2 v_texcoord;
+    void main()
+    {
+        gl_Position = vec4(position, 0.0, 1.0);
+        v_texcoord = texcoord;
+    }
+"""
+
+fragment = """
+    uniform isampler2D tex;
+    in vec2 v_texcoord;
+    out vec4 fragColor;
+
+    void main()
+    {
+        float c = int(texture(tex, v_texcoord).x);
+        fragColor = vec4(c / 256, c / 256, c / 256, 1);
+    }
+"""
+
+app.use('glfw', api='GL', major=3, minor=3, profile='core')
+window = app.Window(width=512, height=512)
+
+@window.event
+def on_draw(dt):
+    window.clear()
+    program.draw(gl.GL_TRIANGLE_STRIP)
+
+program = gloo.Program(vertex, fragment, count=4, version="330")
+dtype = [('position', np.float32, 2),
+         ('texcoord', np.float32, 2)]
+array = np.zeros(4, dtype).view(gloo.VertexArray)
+array['position'] = [(-1,-1), (-1,+1), (+1,-1), (+1,+1)]
+array['texcoord'] = [( 0, 1), ( 0, 0), ( 1, 1), ( 1, 0)]
+program.bind(array)
+
+T = np.linspace(0, 256.0, 32*32).reshape(32, 32, 1).astype(np.int32)
+program['tex'] = T.view(gloo.TextureInteger2D)
+
+app.run()

--- a/glumpy/gl.py
+++ b/glumpy/gl.py
@@ -20,8 +20,10 @@ FormatHandler( 'glumpy',
                    'glumpy.gloo.atlas.Atlas',
                    'glumpy.gloo.texture.Texture2D',
                    'glumpy.gloo.texture.Texture1D',
-                   'glumpy.gloo.texture.FloatTexture2D',
-                   'glumpy.gloo.texture.FloatTexture1D',
+                   'glumpy.gloo.texture.TextureFloat2D',
+                   'glumpy.gloo.texture.TextureFloat1D',
+                   'glumpy.gloo.texture.TextureInteger2D',
+                   'glumpy.gloo.texture.TextureInteger1D',
                    'glumpy.gloo.texture.TextureCube',
                ])
 

--- a/glumpy/gloo/__init__.py
+++ b/glumpy/gloo/__init__.py
@@ -13,6 +13,7 @@ from . texture import Texture
 from . texture import TextureCube
 from . texture import Texture1D, Texture2D
 from . texture import TextureFloat1D, TextureFloat2D
+from . texture import TextureInteger1D, TextureInteger2D
 from . texture import DepthTexture
 from . array import VertexArray
 from . buffer import Buffer

--- a/glumpy/gloo/program.py
+++ b/glumpy/gloo/program.py
@@ -13,7 +13,7 @@ from . globject import GLObject
 from . array import VertexArray
 from . buffer import VertexBuffer, IndexBuffer
 from . shader import VertexShader, FragmentShader, GeometryShader
-from . variable import gl_typeinfo, Uniform, Attribute
+from . variable import gl_typeinfo, Uniform, Attribute, sampler_types
 
 
 
@@ -276,7 +276,7 @@ class Program(GLObject):
             else:
                 uniform = self._uniforms[name]
             gtype = uniform.gtype
-            if gtype in (gl.GL_SAMPLER_1D, gl.GL_SAMPLER_2D, gl.GL_SAMPLER_CUBE):
+            if gtype in sampler_types:
                 uniform._texture_unit = count
                 count += 1
             self._uniforms[name] = uniform

--- a/glumpy/gloo/shader.py
+++ b/glumpy/gloo/shader.py
@@ -79,6 +79,10 @@ class Shader(GLObject):
         'mat4':        gl.GL_FLOAT_MAT4,
         'sampler1D':   gl.GL_SAMPLER_1D,
         'sampler2D':   gl.GL_SAMPLER_2D,
+        'isampler1D':   gl.GL_INT_SAMPLER_1D,
+        'usampler1D':   gl.GL_UNSIGNED_INT_SAMPLER_1D,
+        'isampler2D':   gl.GL_INT_SAMPLER_2D,
+        'usampler2D':   gl.GL_UNSIGNED_INT_SAMPLER_2D,
         'samplerCube': gl.GL_SAMPLER_CUBE,
     }
 

--- a/glumpy/gloo/texture.py
+++ b/glumpy/gloo/texture.py
@@ -38,20 +38,44 @@ from glumpy.gloo.globject import GLObject
 class Texture(GPUData,GLObject):
     """ Generic texture """
 
-    _cpu_formats = { 1: gl.GL_RED,
-                     2: gl.GL_RG,
-                     3: gl.GL_RGB,
-                     4: gl.GL_RGBA }
+    _cpu_formats = {
+        'float': {1: gl.GL_RED, 2: gl.GL_RG,
+                  3: gl.GL_RGB, 4: gl.GL_RGBA},
+        'integer': {1: gl.GL_RED_INTEGER, 2: gl.GL_RG_INTEGER,
+                    3: gl.GL_RGB_INTEGER, 4: gl.GL_RGBA_INTEGER},
+    }
 
-    _gpu_formats = { 1: gl.GL_RED,
-                     2: gl.GL_RG,
-                     3: gl.GL_RGB,
-                     4: gl.GL_RGBA }
-
-    _gpu_float_formats = { 1: gl.GL_R32F,
-                           2: gl.GL_RG32F,
-                           3: gl.GL_RGB32F,
-                           4: gl.GL_RGBA32F }
+    _gpu_formats = {
+        'quantized': {
+            1: gl.GL_R8, 2: gl.GL_RG8,
+            3: gl.GL_RGB8, 4: gl.GL_RGBA8,
+        },
+        'float': {
+            np.dtype(np.float32): {
+                1: gl.GL_R32F, 2: gl.GL_RG32F,
+                3: gl.GL_RGB32F, 4: gl.GL_RGBA32F},
+        },
+        'integer': {
+            np.dtype(np.int8): {
+                1: gl.GL_R8I, 2: gl.GL_RG8I,
+                3: gl.GL_RGB8I, 4: gl.GL_RGBA8I},
+            np.dtype(np.int16): {
+                1: gl.GL_R16I, 2: gl.GL_RG16I,
+                3: gl.GL_RGB16I, 4: gl.GL_RGBA16I},
+            np.dtype(np.int32): {
+                1: gl.GL_R32I, 2: gl.GL_RG32I,
+                3: gl.GL_RGB32I, 4: gl.GL_RGBA32I},
+            np.dtype(np.uint8): {
+                1: gl.GL_R8UI, 2: gl.GL_RG8UI,
+                3: gl.GL_RGB8UI, 4: gl.GL_RGBA8UI},
+            np.dtype(np.uint16): {
+                1: gl.GL_R16UI, 2: gl.GL_RG16UI,
+                3: gl.GL_RGB16UI, 4: gl.GL_RGBA16UI},
+            np.dtype(np.uint32): {
+                1: gl.GL_R32UI, 2: gl.GL_RG32UI,
+                3: gl.GL_RGB32UI, 4: gl.GL_RGBA32UI},
+        }
+    }
 
     _gtypes = { np.dtype(np.int8):    gl.GL_BYTE,
                 np.dtype(np.uint8):   gl.GL_UNSIGNED_BYTE,
@@ -227,8 +251,9 @@ class Texture1D(Texture):
     def __init__(self):
         Texture.__init__(self, gl.GL_TEXTURE_1D)
         self.shape = self._check_shape(self.shape, 1)
-        self._cpu_format = Texture._cpu_formats[self.shape[-1]]
-        self._gpu_format = Texture._gpu_formats[self.shape[-1]]
+        self._cpu_format = Texture._cpu_formats['float'][self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['quantized'][self.shape[-1]]
 
 
     @property
@@ -283,7 +308,19 @@ class TextureFloat1D(Texture1D):
 
     def __init__(self):
         Texture1D.__init__(self)
-        self._gpu_format = Texture._gpu_float_formats[self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['float'][self.dtype][self.shape[-1]]
+
+
+
+class TextureInteger1D(Texture1D):
+    """ 1D integer texture """
+
+    def __init__(self):
+        Texture1D.__init__(self)
+        self._cpu_format = Texture._cpu_formats['integer'][self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['integer'][self.dtype][self.shape[-1]]
 
 
 
@@ -293,8 +330,9 @@ class Texture2D(Texture):
     def __init__(self):
         Texture.__init__(self, gl.GL_TEXTURE_2D)
         self.shape = self._check_shape(self.shape, 2)
-        self._cpu_format = Texture._cpu_formats[self.shape[-1]]
-        self._gpu_format = Texture._gpu_formats[self.shape[-1]]
+        self._cpu_format = Texture._cpu_formats['float'][self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['quantized'][self.shape[-1]]
 
     @property
     def width(self):
@@ -380,7 +418,20 @@ class TextureFloat2D(Texture2D):
 
     def __init__(self):
         Texture2D.__init__(self)
-        self._gpu_format = Texture._gpu_float_formats[self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['float'][self.dtype][self.shape[-1]]
+
+
+
+class TextureInteger2D(Texture2D):
+    """ 2D integer texture """
+
+    def __init__(self):
+        Texture2D.__init__(self)
+        self._cpu_format = Texture._cpu_formats['integer'][self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['integer'][self.dtype][self.shape[-1]]
+
 
 
 class DepthTexture(Texture2D):
@@ -405,8 +456,9 @@ class TextureCube(Texture):
             raise RuntimeError(error)
 
         self.shape = [6] + list(self._check_shape(self.shape[1:], 2))
-        self._cpu_format = Texture._cpu_formats[self.shape[-1]]
-        self._gpu_format = Texture._gpu_formats[self.shape[-1]]
+        self._cpu_format = Texture._cpu_formats['float'][self.shape[-1]]
+        self._gpu_format =\
+            Texture._gpu_formats['quantized'][self.shape[-1]]
 
     @property
     def width(self):

--- a/glumpy/gloo/variable.py
+++ b/glumpy/gloo/variable.py
@@ -88,8 +88,17 @@ gl_typeinfo = {
     gl.GL_FLOAT_MAT4   : (16, gl.GL_FLOAT,        np.float32),
     gl.GL_SAMPLER_1D   : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
     gl.GL_SAMPLER_2D   : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
+    gl.GL_INT_SAMPLER_1D : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
+    gl.GL_UNSIGNED_INT_SAMPLER_1D : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
+    gl.GL_INT_SAMPLER_2D : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
+    gl.GL_UNSIGNED_INT_SAMPLER_2D : ( 1, gl.GL_UNSIGNED_INT, np.uint32),
     gl.GL_SAMPLER_CUBE : ( 1, gl.GL_UNSIGNED_INT, np.uint32)
 }
+
+
+sampler_types = (gl.GL_SAMPLER_1D, gl.GL_SAMPLER_2D, gl.GL_INT_SAMPLER_1D,
+                  gl.GL_UNSIGNED_INT_SAMPLER_1D, gl.GL_INT_SAMPLER_2D,
+                  gl.GL_UNSIGNED_INT_SAMPLER_2D)
 
 
 
@@ -106,7 +115,9 @@ class Variable(GLObject):
                          gl.GL_INT,        gl.GL_BOOL,
                          gl.GL_FLOAT_MAT2, gl.GL_FLOAT_MAT3,
                          gl.GL_FLOAT_MAT4, gl.GL_SAMPLER_1D,
-                         gl.GL_SAMPLER_2D, gl.GL_SAMPLER_CUBE]:
+                         gl.GL_SAMPLER_2D, gl.GL_INT_SAMPLER_1D,
+                         gl.GL_UNSIGNED_INT_SAMPLER_1D, gl.GL_INT_SAMPLER_2D,
+                         gl.GL_UNSIGNED_INT_SAMPLER_2D, gl.GL_SAMPLER_CUBE]:
             raise TypeError("Unknown variable type")
 
         GLObject.__init__(self)
@@ -194,6 +205,10 @@ class Uniform(Variable):
         gl.GL_FLOAT_MAT4:   gl.glUniformMatrix4fv,
         gl.GL_SAMPLER_1D:   gl.glUniform1i,
         gl.GL_SAMPLER_2D:   gl.glUniform1i,
+        gl.GL_INT_SAMPLER_1D:   gl.glUniform1i,
+        gl.GL_UNSIGNED_INT_SAMPLER_1D:   gl.glUniform1i,
+        gl.GL_INT_SAMPLER_2D:   gl.glUniform1i,
+        gl.GL_UNSIGNED_INT_SAMPLER_2D:   gl.glUniform1i,
         gl.GL_SAMPLER_CUBE: gl.glUniform1i
     }
 
@@ -212,7 +227,9 @@ class Uniform(Variable):
         """ Assign new data to the variable (deferred operation) """
 
         # Textures need special handling
-        if self._gtype == gl.GL_SAMPLER_1D:
+        if self._gtype in (gl.GL_SAMPLER_1D,
+                           gl.GL_INT_SAMPLER_1D,
+                           gl.GL_UNSIGNED_INT_SAMPLER_1D):
 
             if isinstance(data, Texture1D):
                 self._data = data
@@ -228,7 +245,9 @@ class Uniform(Variable):
                 else:
                     self._data = data.view(Texture1D)
 
-        elif self._gtype == gl.GL_SAMPLER_2D:
+        elif self._gtype in (gl.GL_SAMPLER_2D,
+                             gl.GL_INT_SAMPLER_2D,
+                             gl.GL_UNSIGNED_INT_SAMPLER_2D):
             if isinstance(data, Texture2D):
                 self._data = data
             elif isinstance(self._data, Texture2D):
@@ -264,7 +283,7 @@ class Uniform(Variable):
 
 
     def _activate(self):
-        if self._gtype in (gl.GL_SAMPLER_1D, gl.GL_SAMPLER_2D, gl.GL_SAMPLER_CUBE):
+        if self._gtype in sampler_types:
             if self.data is not None:
                 log.debug("GPU: Active texture is %d" % self._texture_unit)
                 gl.glActiveTexture(gl.GL_TEXTURE0 + self._texture_unit)
@@ -289,7 +308,7 @@ class Uniform(Variable):
             self._ufunction(self._handle, 1, transpose, self._data)
 
         # Textures (need to get texture count)
-        elif self._gtype in (gl.GL_SAMPLER_1D, gl.GL_SAMPLER_2D, gl.GL_SAMPLER_CUBE):
+        elif self._gtype in sampler_types:
             # texture = self.data
             log.debug("GPU: Activactin texture %d" % self._texture_unit)
             # gl.glActiveTexture(gl.GL_TEXTURE0 + self._unit)


### PR DESCRIPTION
Merge after #138 

`TextureInteger*` can now be used as uniforms.
Please check the example in this PR.
