### PR TITLE
Fix depth test in picking example

### DIFF
--- a/examples/gloo-picking.py
+++ b/examples/gloo-picking.py
@@ -100,7 +100,7 @@ color = np.zeros((window.height,window.width,4),np.ubyte).view(gloo.Texture2D)
 color.interpolation = gl.GL_LINEAR
 pick = np.zeros((window.height,window.width,4),np.ubyte).view(gloo.Texture2D)
 pick.interpolation = gl.GL_LINEAR
-framebuffer = gloo.FrameBuffer(color=[color,pick])
+framebuffer = gloo.FrameBuffer(color=[color,pick], depth=gloo.DepthBuffer(window.width, window.height))
 quad["color"] = color
 
 index = 0


### PR DESCRIPTION
As mentioned in #142, the picking example depth buffer isn't set and depth test could not be properly executed.
This patches the behaviour by adding depth buffer to the framebuffer object.