### PR TITLE
Pyglet docgen fix

### DIFF
--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -22,15 +22,15 @@ and music. It works on Windows, OS X and Linux.
 **Capability**
 
 ========================== ======== ======================== ========
-Multiple windows              ✓     Set GL API                  ✘    
+Multiple windows              ✓     Set GL API                  ✘
 -------------------------- -------- ------------------------ --------
-Non-decorated windows         ✓     Set GL Profile              ✘    
+Non-decorated windows         ✓     Set GL Profile              ✘
 -------------------------- -------- ------------------------ --------
-Resize windows                ✓     Share GL Context            ✓    
+Resize windows                ✓     Share GL Context            ✓
 -------------------------- -------- ------------------------ --------
-Move windows                  ✓     Unicode handling            ✓    
+Move windows                  ✓     Unicode handling            ✓
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 import sys
@@ -79,6 +79,9 @@ def __exit__():
 # ------------------------------------------------------------ availability ---
 try:
     import pyglet
+    # prevent pyglet from failing if sphinx is loaded
+    if hasattr(sys, 'is_pyglet_docgen'):
+        sys.is_pyglet_docgen = False
     __availability__ = True
     __version__ = pyglet.version
     __init__()

--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -82,6 +82,8 @@ try:
     # prevent pyglet from failing if sphinx is loaded
     if hasattr(sys, 'is_pyglet_docgen'):
         sys.is_pyglet_docgen = False
+    if hasattr(sys, 'is_epydoc'):
+        sys.is_epydoc = False
     __availability__ = True
     __version__ = pyglet.version
     __init__()


### PR DESCRIPTION
fixes pyglet error seen here:
https://bitbucket.org/pyglet/pyglet/issues/185/notimplementederror-abstract

pyglet apparently checks `sys.modules` for sphinx and sets a flag which prevents the backend from being imported. this unsets the flag.