### PR TITLE
implement vsync for all backends except freeglut, osxglut

### DIFF
--- a/glumpy/app/__init__.py
+++ b/glumpy/app/__init__.py
@@ -160,6 +160,9 @@ class Window(object):
         if "config" not in kwargs.keys():
             kwargs['config'] = config
 
+        if 'vsync' not in kwargs.keys():
+            kwargs['vsync'] = options.vsync
+
         # Get command line size
         # if options.size:
         #     size = options.size.split(",")

--- a/glumpy/app/window/backends/backend_freeglut.py
+++ b/glumpy/app/window/backends/backend_freeglut.py
@@ -31,7 +31,7 @@ Resize windows                ✓     Share GL Context            ✘
 -------------------------- -------- ------------------------ --------
 Move windows                  ✓     Unicode handling            ✘
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 import sys
@@ -178,7 +178,10 @@ def set_configuration(config):
 class Window(window.Window):
 
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
+
+        if vsync:
+            log.warn('vsync not implemented for freeglut backend')
 
         if len(__windows__) > 0:
             log.critical(

--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -22,15 +22,15 @@ loop.
 **Capability**
 
 ========================== ======== ======================== ========
-Multiple windows              ✓     Set GL API                  ✓    
+Multiple windows              ✓     Set GL API                  ✓
 -------------------------- -------- ------------------------ --------
-Non-decorated windows         ✓     Set GL Profile              ✓    
+Non-decorated windows         ✓     Set GL Profile              ✓
 -------------------------- -------- ------------------------ --------
-Resize windows                ✓     Share GL Context            ✓    
+Resize windows                ✓     Share GL Context            ✓
 -------------------------- -------- ------------------------ --------
-Move windows                  ✓     Unicode handling            ✓    
+Move windows                  ✓     Unicode handling            ✓
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 import os, sys
@@ -187,7 +187,7 @@ def set_configuration(config):
 class Window(window.Window):
 
     def __init__( self, width=512, height=512, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -227,7 +227,7 @@ class Window(window.Window):
             sys.exit()
 
         glfw.glfwMakeContextCurrent(self._native_window)
-        glfw.glfwSwapInterval(0)
+        glfw.glfwSwapInterval(1 if vsync else 0)
 
         # OSX: check framebuffer size / window size. On retina display, they
         #      can be different so we try to correct window size such as having

--- a/glumpy/app/window/backends/backend_osxglut.py
+++ b/glumpy/app/window/backends/backend_osxglut.py
@@ -180,7 +180,7 @@ class Window(window.Window):
                   decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         if vsync:
-            log.warn('vsync not implemented for freeglut backend')
+            log.warn('vsync not implemented for osxglut backend')
 
         if len(__windows__) > 0:
             log.critical(

--- a/glumpy/app/window/backends/backend_osxglut.py
+++ b/glumpy/app/window/backends/backend_osxglut.py
@@ -177,7 +177,10 @@ def set_configuration(config):
 class Window(window.Window):
 
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
+
+        if vsync:
+            log.warn('vsync not implemented for freeglut backend')
 
         if len(__windows__) > 0:
             log.critical(

--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -22,15 +22,15 @@ and music. It works on Windows, OS X and Linux.
 **Capability**
 
 ========================== ======== ======================== ========
-Multiple windows              ✓     Set GL API                  ✘    
+Multiple windows              ✓     Set GL API                  ✘
 -------------------------- -------- ------------------------ --------
-Non-decorated windows         ✓     Set GL Profile              ✘    
+Non-decorated windows         ✓     Set GL Profile              ✘
 -------------------------- -------- ------------------------ --------
-Resize windows                ✓     Share GL Context            ✓    
+Resize windows                ✓     Share GL Context            ✓
 -------------------------- -------- ------------------------ --------
-Move windows                  ✓     Unicode handling            ✓    
+Move windows                  ✓     Unicode handling            ✓
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 import sys
@@ -137,7 +137,7 @@ class Window(window.Window):
 
 
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -156,7 +156,7 @@ class Window(window.Window):
 
         self._native_window = pyglet.window.Window(
             width=self._width, height=self._height, caption=title,
-            resizable=True, vsync=False, config=__configuration__)
+            resizable=True, vsync=vsync, config=__configuration__)
 
         def on_mouse_drag(x, y, dx, dy, button, modifiers):
             # BUGFIX

--- a/glumpy/app/window/backends/backend_pyside.py
+++ b/glumpy/app/window/backends/backend_pyside.py
@@ -21,15 +21,15 @@ tools for rapidly generating bindings for any C++ libraries.
 **Capability**
 
 ========================== ======== ======================== ========
-Multiple windows              ✓     Set GL API                  ✓    
+Multiple windows              ✓     Set GL API                  ✓
 -------------------------- -------- ------------------------ --------
-Non-decorated windows         ✓     Set GL Profile              ✓    
+Non-decorated windows         ✓     Set GL Profile              ✓
 -------------------------- -------- ------------------------ --------
-Resize windows                ✓     Share GL Context            ✓    
+Resize windows                ✓     Share GL Context            ✓
 -------------------------- -------- ------------------------ --------
-Move windows                  ✓     Unicode handling            ✓    
+Move windows                  ✓     Unicode handling            ✓
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 
@@ -150,7 +150,6 @@ def set_configuration(config):
     # ...7868882/enabling-opengl-core-profile-in-qt4-on-os-x
 
     __glformat__ = QtOpenGL.QGLFormat()
-    __glformat__.setSwapInterval(0)
     __glformat__.setRedBufferSize(config.red_size)
     __glformat__.setGreenBufferSize(config.green_size)
     __glformat__.setBlueBufferSize(config.blue_size)
@@ -198,7 +197,7 @@ def set_configuration(config):
 # ------------------------------------------------------------------ Window ---
 class Window(window.Window):
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -214,6 +213,8 @@ class Window(window.Window):
         if config is None:
             config = configuration.Configuration()
         set_configuration(config)
+
+        __glformat__.setSwapInterval(1 if vsync else 0)
 
         self._native_app = QtGui.QApplication.instance()
         if self._native_app is None:

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -24,15 +24,15 @@ v5. The bindings are implemented as a set of Python modules and contain over
 **Capability**
 
 ========================== ======== ======================== ========
-Multiple windows              ✓     Set GL API                  ✓    
+Multiple windows              ✓     Set GL API                  ✓
 -------------------------- -------- ------------------------ --------
-Non-decorated windows         ✓     Set GL Profile              ✓    
+Non-decorated windows         ✓     Set GL Profile              ✓
 -------------------------- -------- ------------------------ --------
-Resize windows                ✓     Share GL Context            ✓    
+Resize windows                ✓     Share GL Context            ✓
 -------------------------- -------- ------------------------ --------
-Move windows                  ✓     Unicode handling            ✓    
+Move windows                  ✓     Unicode handling            ✓
 -------------------------- -------- ------------------------ --------
-Fullscreen                    ✓     Scroll event                ✓    
+Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
 
@@ -154,7 +154,6 @@ def set_configuration(config):
     # ...7868882/enabling-opengl-core-profile-in-qt4-on-os-x
 
     __glformat__ = QtOpenGL.QGLFormat()
-    __glformat__.setSwapInterval(0)
     __glformat__.setRedBufferSize(config.red_size)
     __glformat__.setGreenBufferSize(config.green_size)
     __glformat__.setBlueBufferSize(config.blue_size)
@@ -202,7 +201,7 @@ def set_configuration(config):
 # ------------------------------------------------------------------ Window ---
 class Window(window.Window):
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -218,6 +217,8 @@ class Window(window.Window):
         if config is None:
             config = configuration.Configuration()
         set_configuration(config)
+
+        __glformat__.setSwapInterval(1 if vsync else 0)
 
         self._native_app = QtWidgets.QApplication.instance()
         if self._native_app is None:

--- a/glumpy/app/window/backends/backend_sdl.py
+++ b/glumpy/app/window/backends/backend_sdl.py
@@ -148,7 +148,6 @@ def set_configuration(configuration):
     """ Set gl configuration """
 
     global __flags__
-    pygame.display.gl_set_attribute( pygame.GL_SWAP_CONTROL, 0 )
     pygame.display.gl_set_attribute( pygame.GL_RED_SIZE, configuration.red_size)
     pygame.display.gl_set_attribute( pygame.GL_GREEN_SIZE, configuration.green_size)
     pygame.display.gl_set_attribute( pygame.GL_BLUE_SIZE, configuration.blue_size)
@@ -174,7 +173,7 @@ class Window(window.Window):
     ''' '''
 
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         if len(__windows__) > 0:
             log.critical(
@@ -196,6 +195,9 @@ class Window(window.Window):
         if config is None:
             config = configuration.Configuration()
         set_configuration(config)
+
+        pygame.display.gl_set_attribute( pygame.GL_SWAP_CONTROL, 1 if vsync else 0)
+
 
         flags = __flags__
         if self._decoration == False:

--- a/glumpy/app/window/backends/backend_sdl2.py
+++ b/glumpy/app/window/backends/backend_sdl2.py
@@ -188,7 +188,7 @@ class Window(window.Window):
     """ """
 
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
         """ """
 
         window.Window.__init__(self, width=width,
@@ -223,7 +223,7 @@ class Window(window.Window):
                                                     width, height, flags)
         self._native_context = sdl2.SDL_GL_CreateContext(self._native_window)
         self._native_id = sdl2.SDL_GetWindowID(self._native_window)
-        sdl2.SDL_GL_SetSwapInterval(0)
+        sdl2.SDL_GL_SetSwapInterval(1 if vsync else 0)
 
         # OSX: check framebuffer size / window size. On retina display, they
         #      can be different so we try to correct window size such as having

--- a/glumpy/app/window/backends/backend_template.py
+++ b/glumpy/app/window/backends/backend_template.py
@@ -88,7 +88,7 @@ class Window(window.Window):
     """
 
     def __init__( self, width=512, height=512, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -107,7 +107,7 @@ class Window(window.Window):
         # Each on the events below must be called at some point This means you
         # have to connect to key and mouse events using toolkit native methods
         # and dispatch the event to glumpy event stack.
-        
+
         # self.dispatch_event('on_show')
         # self.dispatch_event('on_hide')
         # self.dispatch_event('on_close')
@@ -141,7 +141,7 @@ class Window(window.Window):
     def set_title(self, title):
         """ Set window title """
         raise(NotImplemented)
-    
+
     def get_title(self, title):
         """ Get window title """
         raise(NotImplemented)
@@ -180,7 +180,7 @@ def windows():
 # ----------------------------------------------------------------- process ---
 def process(dt):
     """ Process events for all windows. Non blocking. """
-    
+
     # Poll for and process events
     # -> Add toolkit specific code here to process events
     # -> Must return (non bloking)


### PR DESCRIPTION
vsync available via command line option and window keyword arg.

not clear how to implement for freeglut and osxglut, so just log a warning if vsync is True. (though I don't see tearing with osxglut at all).

tested for qt5, glfw, osxglut. the other backends do not work for me for various reasons.

closes #145 