### PR TITLE
Minor typo fix in usage example

### DIFF
--- a/glumpy/transforms/position.py
+++ b/glumpy/transforms/position.py
@@ -33,7 +33,7 @@ class Position(Transform):
          program = Program(vertex, fragment)
          program["transform"] = Position("position")
          # or program["transform"] = Position("position.y","position.x")
-         # or program["transform"] = Position("vec2(position.y,position.x"))
+         # or program["transform"] = Position("vec2(position.y,position.x)")
          ...
     """
     


### PR DESCRIPTION
Line 36, changed # or program["transform"] = Position("vec2(position.y,position.x")) to # or program["transform"] = Position("vec2(position.y,position.x)").

Very ,very minor typo but has been bothering me. 