### PR TITLE
Removed usage default from Buffer in buffer.py.

### DIFF
--- a/glumpy/gloo/buffer.py
+++ b/glumpy/gloo/buffer.py
@@ -36,7 +36,7 @@ class Buffer(GPUData,GLObject):
     (gl.GL_ARRAY_BUFFER or gl.GL_ELEMENT_ARRAY_BUFFER).
     """
 
-    def __init__(self, target, usage=gl.GL_DYNAMIC_DRAW):
+    def __init__(self, target, usage):
         GLObject.__init__(self)
         self._target = target
         self._usage = usage


### PR DESCRIPTION
Since the Buffer is a generic object it should not have the default usage argument.
Note how the usage has a default value in VertexBuffer and IndexBuffer, so it is redundant to add it in Buffer also. 