### PR TITLE
Moved clear after activate in framebuffer.py doc.

### DIFF
--- a/glumpy/gloo/framebuffer.py
+++ b/glumpy/gloo/framebuffer.py
@@ -25,8 +25,8 @@ Read more on framebuffers on `OpenGL Wiki
 
      @window.event
      def on_draw(dt):
-         window.clear()
          framebuffer.activate()
+         window.clear()
          quad.draw(gl.GL_TRIANGLE_STRIP)
          framebuffer.deactivate()
 """


### PR DESCRIPTION
You have to clear when the framebuffer is bound, or else it is just clearing the window and not your renderbuffers.