### PR TITLE
Added clear function to FrameBuffer.

### DIFF
--- a/glumpy/gloo/framebuffer.py
+++ b/glumpy/gloo/framebuffer.py
@@ -25,8 +25,8 @@ Read more on framebuffers on `OpenGL Wiki
 
      @window.event
      def on_draw(dt):
-         window.clear()
          framebuffer.activate()
+         framebuffer.clear()
          quad.draw(gl.GL_TRIANGLE_STRIP)
          framebuffer.deactivate()
 """
@@ -353,6 +353,15 @@ class FrameBuffer(GLObject):
             self._pending_attachments.append((target, self.stencil))
             self._need_attach = True
 
+    def clear(self):
+        """ Clear the framebuffer """
+        
+        clearflags = gl.GL_COLOR_BUFFER_BIT
+        if self._depth is not None:
+            clearflags |= gl.GL_DEPTH_BUFFER_BIT
+        if self._stencil is not None:
+            clearflags |= gl.GL_STENCIL_BUFFER_BIT
+        gl.glClear(clearflags)
 
     def _create(self):
         """ Create framebuffer on GPU """


### PR DESCRIPTION
Instead of calling window.clear() when we have a framebuffer activated we should call framebuffer.clear().
Then it makes sure to clear the renderbuffers that are set.
This also fixes: https://github.com/glumpy/glumpy/pull/189