### PR TITLE
Changed framebuffer width, height default to None.

### DIFF
--- a/glumpy/gloo/framebuffer.py
+++ b/glumpy/gloo/framebuffer.py
@@ -184,8 +184,8 @@ class FrameBuffer(GLObject):
 
         GLObject.__init__(self)
 
-        self._width = 0
-        self._height = 0
+        self._width = None
+        self._height = None
         self._color = None
         self._depth = None
         self._stencil = None
@@ -216,9 +216,9 @@ class FrameBuffer(GLObject):
         self._color = []
 
         for i,buffer in enumerate(buffers):
-            if self.width != 0 and self.width != buffer.width:
+            if self.width is not None and self.width != buffer.width:
                 raise ValueError("Buffer width does not match")
-            elif self.height != 0 and self.height != buffer.height:
+            elif self.height is not None and self.height != buffer.height:
                 raise ValueError("Buffer height does not match")
             self._width = buffer.width
             self._height = buffer.height
@@ -245,9 +245,9 @@ class FrameBuffer(GLObject):
     def depth(self, buffer):
         """ Depth buffer attachment (read/write) """
 
-        if self.width != 0 and self.width != buffer.width:
+        if self.width is not None and self.width != buffer.width:
             raise ValueError("Buffer width does not match")
-        elif self.height != 0 and self.height != buffer.height:
+        elif self.height is not None and self.height != buffer.height:
             raise ValueError("Buffer height does not match")
         self._width = buffer.width
         self._height = buffer.height
@@ -273,9 +273,9 @@ class FrameBuffer(GLObject):
     def stencil(self, buffer):
         """ Stencil buffer attachment (read/write) """
 
-        if self.width != 0 and self.width != buffer.width:
+        if self.width is not None and self.width != buffer.width:
             raise ValueError("Buffer width does not match")
-        elif self.height != 0 and self.height != buffer.height:
+        elif self.height is not None and self.height != buffer.height:
             raise ValueError("Buffer height does not match")
         self._width = buffer.width
         self._height = buffer.height


### PR DESCRIPTION
I changed the framebuffer width and height default value to none, and corrected the checks in the color, depth and stencil setters accordingly. The reason None is better is because it is possible to have a renderbuffer with e.g. 0 width and 10 height.
Compare np.zeros((0, 10)), which is allowed in numpy. According to the opengl documentation the only limitation is that it should be nonnegative.