### PR TITLE
Fix full screen bug when using GLFW backend

### DIFF
--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -221,8 +221,10 @@ class Window(window.Window):
         if config is None:
             config = configuration.Configuration()
         set_configuration(config)
+
+        monitor = glfw.glfwGetMonitors()[0] if fullscreen else None
         self._native_window = glfw.glfwCreateWindow( self._width, self._height,
-                                                     self._title, None, None)
+                                                     self._title, monitor, None)
 
         if not self._native_window:
             log.critical("Window creation failed")


### PR DESCRIPTION
The fullscreen parameter does not work in 193 line of backend_glfw.py.
```
class Window(window.Window):

    def __init__( self, width=512, height=512, title=None, visible=True, aspect=None,
                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
```