### PR TITLE
Add TrackballPan transform, a pan-able Trackball

### DIFF
--- a/examples/transform-trackballPan.py
+++ b/examples/transform-trackballPan.py
@@ -1,0 +1,87 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
+# Distributed under the (new) BSD License.
+# -----------------------------------------------------------------------------
+import numpy as np
+from glumpy import app, gl, glm, gloo
+from glumpy.geometry import colorcube
+from glumpy.transforms import TrackballPan, Position
+
+
+vertex = """
+
+uniform vec4 u_color;
+attribute vec3 position;
+attribute vec4 color;
+varying vec4 v_color;
+
+void main()
+{
+    v_color = u_color * color;
+    gl_Position = <transform>;
+}
+"""
+
+fragment = """
+varying vec4 v_color;
+
+void main()
+{
+    gl_FragColor = v_color;
+}
+"""
+
+window = app.Window(width=1024, height=1024,
+                    color=(0.30, 0.30, 0.35, 1.00))
+
+# Build cube data
+V, I, O = colorcube()
+vertices = V.view(gloo.VertexBuffer)
+faces    = I.view(gloo.IndexBuffer)
+outline  = O.view(gloo.IndexBuffer)
+
+cube = gloo.Program(vertex, fragment)
+cube.bind(vertices)
+
+# create an instance of the TrackballPan object.
+trackball = TrackballPan(Position("position"), znear=3, zfar=10, distance=5)
+cube['transform'] = trackball
+
+trackball.aspect = 1
+# rotation around the X axis
+trackball.phi = 0
+# rotation around the Y axis
+trackball.theta = 0
+trackball.zoom = 50
+
+
+@window.event
+def on_draw(dt):
+    window.clear()
+
+    # Filled cube
+    gl.glDisable(gl.GL_BLEND)
+    gl.glEnable(gl.GL_DEPTH_TEST)
+    gl.glEnable(gl.GL_POLYGON_OFFSET_FILL)
+    cube['u_color'] = 1, 1, 1, 1
+    cube.draw(gl.GL_TRIANGLES, faces)
+
+    # Outlined cube
+    gl.glDisable(gl.GL_POLYGON_OFFSET_FILL)
+    gl.glEnable(gl.GL_BLEND)
+    gl.glDepthMask(gl.GL_FALSE)
+    cube['u_color'] = 0, 0, 0, 1
+    cube.draw(gl.GL_LINES, outline)
+    gl.glDepthMask(gl.GL_TRUE)
+
+
+window.attach(cube['transform'])
+
+# OpenGL
+gl.glEnable(gl.GL_DEPTH_TEST)
+gl.glPolygonOffset(1, 1)
+gl.glEnable(gl.GL_LINE_SMOOTH)
+gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+
+# Run
+app.run()

--- a/glumpy/library/transforms/trackball-pan.glsl
+++ b/glumpy/library/transforms/trackball-pan.glsl
@@ -1,0 +1,15 @@
+
+
+
+
+uniform mat4 trackball_view;
+uniform mat4 trackball_model;
+uniform mat4 trackball_projection;
+uniform vec2 trackball_pan;
+
+vec4 transform(vec4 position)
+{
+    vec4 p =  trackball_projection * trackball_view * trackball_model * position;
+    p.xy = trackball_pan * p.w + p.xy;
+    return p;
+}

--- a/glumpy/transforms/__init__.py
+++ b/glumpy/transforms/__init__.py
@@ -6,6 +6,7 @@ from . panzoom import PanZoom
 from . viewport import Viewport
 from . arcball import Arcball
 from . trackball import Trackball
+from . trackball_pan import TrackballPan
 from . xyz import X,Y,Z
 from . rotate import Rotate
 from . position import Position

--- a/glumpy/transforms/trackball_pan.py
+++ b/glumpy/transforms/trackball_pan.py
@@ -1,0 +1,225 @@
+import numpy as np
+from . import _trackball
+from . transform import Transform
+from glumpy import gl, glm, library
+
+
+class TrackballPan(Transform):
+    """
+    3D trackball transform
+
+    :param float aspect:
+       Indicate what is the aspect ratio of the object displayed. This is
+       necessary to convert pixel drag move in oject space coordinates.
+       Default is None.
+
+    :param float znear:
+       Near clip plane. Default is 2.
+
+    :param float zfar: 
+       Distance clip plane. Default is 1000.
+
+    :param float theta:
+       Angle (in degrees) around the z axis. Default is 45.
+
+    :param float phi: 
+       Angle (in degrees) around the x axis. Default is 45.
+
+    :param float distance:
+       Distance from the trackball to the object.  Default is 8.
+
+    :param float zoom:
+           Zoom level. Default is 35.
+
+    The trackball transform simulates a virtual trackball (3D) that can rotate
+    around the origin using intuitive mouse gestures.
+
+    The transform is connected to the following events:
+
+      * ``on_attach``: Transform initialization
+      * ``on_resize``: Tranform update to maintain aspect
+      * ``on_mouse_scroll``: Zoom in & out (user action)
+      * ``on_mouse_grab``: Drag (user action)
+
+    **Usage example**:
+
+      .. code:: python
+
+         vertex = '''
+         attribute vec2 position;
+         void main()
+         {
+             gl_Position = <transform>(vec4(position, 0.0, 1.0));
+         } '''
+
+         ...
+         window = app.Window(width=800, height=800)
+         program = gloo.Program(vertex, fragment, count=4)
+         ...
+         program['transform'] = Trackball(aspect=1)
+         window.attach(program['transform'])
+         ...
+    """
+
+    aliases = { "view"       : "trackball_view",
+                "model"      : "trackball_model",
+                "projection" : "trackball_projection",
+                "pan"        : "trackball_pan" }
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the transform.
+        """
+
+        code = library.get("transforms/trackball-pan.glsl")
+        Transform.__init__(self, code, *args, **kwargs)
+
+        self._aspect = Transform._get_kwarg("aspect", kwargs) or 1
+        self._znear = Transform._get_kwarg("znear", kwargs) or 2.0
+        self._zfar = Transform._get_kwarg("zfar", kwargs) or 1000.0
+        theta = Transform._get_kwarg("theta", kwargs) or 45
+        phi = Transform._get_kwarg("phi", kwargs) or 45
+        self._distance = Transform._get_kwarg("distance", kwargs) or 8
+        self._zoom = Transform._get_kwarg("zoom", kwargs) or 35
+        self._width = 1
+        self._height = 1
+        self._window_aspect = 1
+        self._view_x = 0
+        self._view_y = 0
+        self._shift = False
+
+        self._trackball = _trackball.Trackball(45,45)
+        self._projection = np.eye(4, dtype=np.float32)
+        self._view = np.eye(4, dtype=np.float32)
+        glm.translate(self._view, 0, 0, -abs(self._distance))
+
+
+
+    @property
+    def distance(self):
+        """ Distance from the trackball to the object """
+
+        return self._distance
+
+    @distance.setter
+    def distance(self, distance):
+        """ Distance from the trackball to the object """
+
+        self._distance = abs(distance)
+        self._view = np.eye(4, dtype=np.float32)
+        glm.translate(self._view, 0, 0, -abs(self._distance))
+        self["view"] = self._view
+
+
+    @property
+    def theta(self):
+        """ Angle (in degrees) around the z axis """
+
+        return self._trackball.theta
+
+    @theta.setter
+    def theta(self, theta):
+        """ Angle (in degrees) around the z axis """
+
+        self._trackball.theta = theta
+        self["model"] = self._trackball.model
+
+
+    @property
+    def phi(self):
+        """ Angle (in degrees) around the x axis """
+
+        return self._trackball.phi
+
+    @phi.setter
+    def phi(self, phi):
+        """ Angle (in degrees) around the x axis """
+
+        self._trackball.phi = phi
+        self["model"] = self._trackball.model
+
+
+    @property
+    def zoom(self):
+        """ Zoom level (aperture angle in degrees) """
+
+        return self._zoom
+
+
+    @phi.setter
+    def zoom(self, value):
+        """ Zoom level (aperture angle in degrees) """
+
+        aspect = self._window_aspect * self._aspect
+        self._zoom = min(max(value, 1.0), 179.0)
+        self['projection'] = glm.perspective(self._zoom, aspect,
+                                             self._znear, self._zfar)
+
+    @property
+    def aspect(self):
+        """ Projection aspect """
+
+        return self._aspect
+
+
+    @aspect.setter
+    def aspect(self, value):
+        """ Projection aspect """
+
+        aspect = self._window_aspect * self._aspect
+        self['projection'] = glm.perspective(self._zoom, aspect,
+                                             self._znear, self._zfar)
+
+
+    def on_attach(self, program):
+        self["view"] = self._view
+        self["model"] = self._trackball.model
+        self["projection"] = self._projection
+
+
+    def on_resize(self, width, height):
+        self._width  = float(width)
+        self._height = float(height)
+        self._window_aspect = self._width / self._height
+        aspect = self._window_aspect * self._aspect
+        self['projection'] = glm.perspective(self._zoom, aspect,
+                                             self._znear, self._zfar)
+        Transform.on_resize(self, width, height)
+
+
+
+    def on_mouse_drag(self, x, y, dx, dy, button):
+        if self._shift: # shift button is currently pressed
+            # print(self._znear, self._zfar)
+            dx = 2 * (dx / self._width)
+            dy = -2 * (dy / self._height)
+            self['pan'] = self._view_x, self._view_y
+            self._view_x += dx
+            self._view_y += dy
+            aspect = self._window_aspect * self._aspect
+        else:
+            width = self._width
+            height = self._height
+            x  = (x*2.0 - width)/width
+            dx = (2.*dx)/width
+            y  = (height - y*2.0)/height
+            dy = -(2.*dy)/height
+            self._trackball.drag_to(x,y,dx,dy)
+            self["model"] = self._trackball.model
+
+    def on_mouse_scroll(self, x, y, dx, dy):
+        width = self._width
+        height = self._height
+        aspect = self._window_aspect * self._aspect
+        self._zoom = min(max(self._zoom*(1-dy/100), 1.0), 179.0)
+        #print(self._zoom)
+        self['projection'] = glm.perspective(self._zoom, aspect,
+                                             self._znear, self._zfar)
+
+    def on_key_press(self, k, m):
+        #print('p', k, m)
+        if m == 1:
+            self._shift = True
+
+    def on_key_release(self, k, m):
+        self._shift = False


### PR DESCRIPTION
The TrackballPan transform is similar to the basic Trackball transform.
However, when the user holds the shift button, dragging the mouse will result in panning the screen (after
projection).
An example of its usage is included.

Resolves glumpy/glumpy#94