### PR TITLE
Support graphics/collection adding vertex shader from external script file

### DIFF
--- a/glumpy/graphics/collections/collection.py
+++ b/glumpy/graphics/collections/collection.py
@@ -12,7 +12,7 @@ interface.
 
 import os
 import numpy as np
-from glumpy import gloo, gl
+from glumpy import gloo, gl, library
 from glumpy.gloo.program import Program
 from glumpy.transforms import Position, Viewport
 from . util import fetchcode
@@ -105,7 +105,7 @@ class Collection(BaseCollection):
         self._defaults = defaults
 
         # Build program (once base collection is built)
-        saved = vertex
+        saved = library.get(vertex)
         vertex = ""
 
         if self.utype is not None:


### PR DESCRIPTION
The `Collection` class in `graphics/collections/collection.py` has a `vertex` arg that only allows for pure string shader code like
```
vertex = """
uniform float rows, cols;
varying float v_x;
varying vec4 v_color;
void main()
{
...
}
"""
```
, but not the filename of an external shader script file as
```
vertex = './shader.vert'
```
due to some attributes are to be inserted in the `Collection` class initialization.

By simply calling `saved = library.get(vertex)` rather than `saved = vertex`, this class can support shader script filename as an input just like the `Program` class.