### PR TITLE
Two fixes:

### DIFF
--- a/glumpy/gloo/variable.py
+++ b/glumpy/gloo/variable.py
@@ -384,7 +384,7 @@ class Attribute(Variable):
     def _deactivate(self):
         if isinstance(self.data,VertexBuffer):
             self.data.deactivate()
-            if self.handle > 0:
+            if self.handle >= 0:
                 gl.glDisableVertexAttribArray(self.handle)
         elif isinstance(self.data,VertexArray):
             self.data.deactivate()

--- a/glumpy/graphics/collections/agg_glyph_collection.py
+++ b/glumpy/graphics/collections/agg_glyph_collection.py
@@ -25,8 +25,8 @@ class AggGlyphCollection(Collection):
             vertex = library.get('collections/agg-glyph.vert')
 
         if "fragment" in kwargs.keys():
-            fragment = kwargs["vertex"]
-            del kwargs["vertex"]
+            fragment = kwargs["fragment"]
+            del kwargs["fragment"]
         else:
             fragment = library.get('collections/agg-glyph.frag')
 


### PR DESCRIPTION
  - In AggGlyphCollection, incorrect key is referenced when checking for a fragment shader
  - In Attribute, if the handle was 0 then glDisableVertexAttribArray wasn't called