### PR TITLE
Added screen kwarg for backend_pyglet.set_fullscreen & backend_qt5 fullscreen getter/setter

### DIFF
--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -366,6 +366,11 @@ class Window(window.Window):
     def destroy(self):
         glfw.glfwDestroyWindow(self._native_window)
 
+
+    def get_screen(self):
+        
+        glfw.glfwGetWindowMonitor()
+
     def set_title(self, title):
         glfw.glfwSetWindowTitle( self._native_window, title)
         self._title = title

--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -241,18 +241,27 @@ class Window(window.Window):
     def hide(self):
         self._native_window.set_visible(False)
 
-    def set_fullscreen(self, state):
-        self._native_window.set_fullscreen(state)
+    def set_fullscreen(self, state, screen=None):
+        if screen is not None:
+            if not(isinstance(screen, pyglet.canvas.Screen)) and isinstance(screen, int):
+                screens = self._native_window.canvas.display.get_screens()
+                screen = screens[screen]
+
+        self._native_window.set_fullscreen(state, screen=screen)
+        self._fullscreen = state
+
+    def get_fullscreen(self):
+        return self._fullscreen
 
     def set_title(self, title):
         self._native_window.set_caption(title)
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):
-        self._window.set_size(width, height)
+        self._native_window.set_size(width, height)
         self._width  = self._native_window.width
         self._height = self._native_window.height
 

--- a/glumpy/app/window/backends/backend_pyglet.py
+++ b/glumpy/app/window/backends/backend_pyglet.py
@@ -242,10 +242,9 @@ class Window(window.Window):
         self._native_window.set_visible(False)
 
     def set_fullscreen(self, state, screen=None):
-        if screen is not None:
-            if not(isinstance(screen, pyglet.canvas.Screen)) and isinstance(screen, int):
-                screens = self._native_window.canvas.display.get_screens()
-                screen = screens[screen]
+        if isinstance(screen, int):
+            screens = self._native_window.canvas.display.get_screens()
+            screen = screens[screen]
 
         self._native_window.set_fullscreen(state, screen=screen)
         self._fullscreen = state
@@ -259,6 +258,15 @@ class Window(window.Window):
 
     def get_title(self):
         return self._title
+
+    def set_screen(self, screen):
+        if isinstance(screen, int):
+            self._screen = screen
+        else:
+            self._screen = pyglet.canvas.get_display().get_screens().index(screen)
+
+    def get_screen(self):
+        return pyglet.canvas.get_display().get_screens()[self._screen]
 
     def set_size(self, width, height):
         self._native_window.set_size(width, height)

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -357,7 +357,7 @@ class Window(window.Window):
         self._native_window.setWindowTitle(self._title)
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):
@@ -369,6 +369,17 @@ class Window(window.Window):
         self._width = self._native_window.geometry().width()
         self._height = self._native_window.geometry().height()
         return self._width, self._height
+
+    def set_fullscreen(self, fullscreen):
+        if fullscreen:
+            self._native_window.showFullScreen()
+        else:
+            self._native_window.showNormal()
+        self._fullscreen = fullscreen
+        self.get_size()
+
+    def get_fullscreen(self):
+        return self._fullscreen
 
     def set_position(self, x, y):
         self._native_window.move(x,y)

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -370,7 +370,10 @@ class Window(window.Window):
         self._height = self._native_window.geometry().height()
         return self._width, self._height
 
-    def set_fullscreen(self, fullscreen):
+    def set_fullscreen(self, fullscreen, screen=None):
+        if screen is not None:
+            self.set_screen(screen)
+
         if fullscreen:
             self._native_window.showFullScreen()
         else:
@@ -380,6 +383,14 @@ class Window(window.Window):
 
     def get_fullscreen(self):
         return self._fullscreen
+
+    def set_screen(self, screen):
+        if isinstance(screen, int):
+            screen = self._native_app.screens()[screen]
+        self._native_window.windowHandle().setScreen(screen)
+
+    def get_screen(self):
+        return self._native_window.windowHandle().screen()
 
     def set_position(self, x, y):
         self._native_window.move(x,y)

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -379,14 +379,17 @@ class Window(window.Window):
         else:
             self._native_window.showNormal()
         self._fullscreen = fullscreen
-        self.get_size()
 
     def get_fullscreen(self):
         return self._fullscreen
 
     def set_screen(self, screen):
         if isinstance(screen, int):
+            self._screen = screen
             screen = self._native_app.screens()[screen]
+        else:
+            self._screen = self._native_app.screens().index(screen)
+
         self._native_window.windowHandle().setScreen(screen)
 
     def get_screen(self):

--- a/glumpy/app/window/window.py
+++ b/glumpy/app/window/window.py
@@ -283,7 +283,7 @@ class Window(event.EventDispatcher):
         """ Get window position """
         log.warn('%s backend cannot get position' %  self._backend.name())
 
-    def set_fullscreen(self, fullsrceen):
+    def set_fullscreen(self, fullscreen):
         """ Set window fullscreen mode """
         log.warn('%s backend cannot set fullscreen mode' % self._backend.name())
 

--- a/glumpy/app/window/window.py
+++ b/glumpy/app/window/window.py
@@ -130,7 +130,7 @@ class Window(event.EventDispatcher):
     """
 
     def __init__(self, width=256, height=256, title=None, visible=True, aspect=None,
-                 decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1)):
+                 decoration=True, fullscreen=False, screen=None, config=None, context=None, color=(0,0,0,1)):
         """
         Create a window.
         """
@@ -145,6 +145,7 @@ class Window(event.EventDispatcher):
         self._height = height
         self._title = (title or sys.argv[0])
         self._visible = visible
+        self._screen = screen
         self._fullscreen = fullscreen
         self._decoration = decoration
         self._clock = None
@@ -282,6 +283,14 @@ class Window(event.EventDispatcher):
     def get_position(self):
         """ Get window position """
         log.warn('%s backend cannot get position' %  self._backend.name())
+
+    def set_screen(self, screen):
+        """ Set window screen """
+        log.warn('%s backend cannot set screen' % self._backend.name())
+
+    def get_screen(self):
+        """ Get window screen """
+        log.warn('%s backend cannot get screen' % self._backend.name())
 
     def set_fullscreen(self, fullscreen):
         """ Set window fullscreen mode """


### PR DESCRIPTION
With these changes 

1. the **pyglet backend** would allow for the selection of a screen when switching fullscreen on (this would resolve #225 )
and
2. fullscreen would be enabled for the **qt5 backend** (I was wondering why this doesn't seem to be implemented although it states in the documentation that it should be). I also added separate setter/getter for the screen and an opt. argument for selecting the screen when calling set_fullscreen