### PR TITLE
sdl2 namespace missing for SDL_WINDOW_HIDDEN variable

### DIFF
--- a/glumpy/app/window/backends/backend_sdl2.py
+++ b/glumpy/app/window/backends/backend_sdl2.py
@@ -213,7 +213,7 @@ class Window(window.Window):
         if visible:
             flags |= sdl2.SDL_WINDOW_SHOWN
         else:
-            flags |= SDL_WINDOW_HIDDEN
+            flags |= sdl2.SDL_WINDOW_HIDDEN
         if not decoration:
             flags |= sdl2.SDL_WINDOW_BORDERLESS
 


### PR DESCRIPTION
In backend_sdl2.py, line 216

This:
flags |= SDL_WINDOW_HIDDEN

Should've been:
flags |= sdl2.SDL_WINDOW_HIDDEN

I found this when I tried to set the visible flag to false when creating a window.