### PR TITLE
Changed time.clock function for time.perf_counter

### DIFF
--- a/glumpy/app/clock.py
+++ b/glumpy/app/clock.py
@@ -161,7 +161,7 @@ if sys.platform in ('win32', 'cygwin'):
                 0, ctypes.c_void_p(), ctypes.c_void_p(), False)
             _kernel32.WaitForSingleObject(self._timer, 0xffffffff)
 
-    _default_time_function = time.clock
+    _default_time_function = time.perf_counter
 
 else:
     _c_file = ctypes.util.find_library('c')

--- a/glumpy/app/clock.py
+++ b/glumpy/app/clock.py
@@ -612,7 +612,7 @@ class Clock(_ClockBase):
         divs = 1
         while True:
             next_ts = last_ts
-            for i in range(divs - 1):
+            for _ in range(divs - 1):
                 next_ts += dt
                 if not taken(next_ts, dt / 4):
                     return next_ts

--- a/glumpy/app/clock.py
+++ b/glumpy/app/clock.py
@@ -161,7 +161,10 @@ if sys.platform in ('win32', 'cygwin'):
                 0, ctypes.c_void_p(), ctypes.c_void_p(), False)
             _kernel32.WaitForSingleObject(self._timer, 0xffffffff)
 
-    _default_time_function = time.perf_counter
+    if sys.version_info < (3, 8):
+        _default_time_function = time.clock
+    else:
+        _default_time_function = time.perf_counter
 
 else:
     _c_file = ctypes.util.find_library('c')


### PR DESCRIPTION
While trying to run a glumpy application using Python 3.8, I've received the following error:

**AttributeError: module 'time' has no attribute 'clock'**

I then modified the function **time.clock** for **time.perf_counter**, as mentioned in this [post](https://stackoverflow.com/questions/58569361/attributeerror-module-time-has-no-attribute-clock-in-python-3-8), and it fixed the problem.