### PR TITLE
Added fetch_build_eggs to setup.py for isolated builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@
 # the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 import os
+from setuptools import dist, setup, Extension
+
+dist.Distribution().fetch_build_eggs(['Cython>=0.15.1', 'numpy>=1.10'])
+
 import numpy
 from Cython.Distutils import build_ext
-from setuptools import setup, Extension
+
 
 if __name__ == "__main__":
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py36
+
+commands =
+    python setup.py install


### PR DESCRIPTION
Hi there! I love the package, but I was having difficulty installing it in an isolated environment like tox or a CI system. Unfortunately, the requirements file is not enough because `glumpy` is alphabetically before `numpy` and the setup will fail with the following error:

```
Collecting glumpy==1.1.0
  Using cached glumpy-1.1.0.tar.gz (503 kB)
    ERROR: Command errored out with exit status 1:
     command: [REDACTED]/.tox/py36/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-s9j9mhqj/glumpy/setup.py'"'"'; __file__='"'"'/tmp/pip-install-s9j9mhqj/glumpy/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-lc7irsba
         cwd: /tmp/pip-install-s9j9mhqj/glumpy/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-s9j9mhqj/glumpy/setup.py", line 8, in <module>
        import numpy
    ModuleNotFoundError: No module named 'numpy'
```

I added one line in the `setup.py` to install cython and numpy if it doesn't already exist.