### PR TITLE
Fix syntax error in translate.glsl

### DIFF
--- a/glumpy/library/transforms/translate.glsl
+++ b/glumpy/library/transforms/translate.glsl
@@ -11,7 +11,7 @@ vec2 forward(vec2 P)
 { return P + translate_translate.xy; }
 
 vec3 forward(float x, float y, float z)
-{ return vec3(x,y,z) + translate_translate); }
+{ return vec3(x,y,z) + translate_translate; }
 
 vec3 forward(vec3 P)
 { return P + translate_translate; }
@@ -26,7 +26,7 @@ vec2 inverse(vec2 P)
 { return P - translate_translate.xy; }
 
 vec3 inverse(float x, float y, float z)
-{ return vec3(x,y,z) - translate_translate); }
+{ return vec3(x,y,z) - translate_translate; }
 
 vec3 inverse(vec3 P)
 { return P - translate_translate; }


### PR DESCRIPTION
Problem:
- The translate.glsl file has an errant ')' in two methods that prevents
  the shader from compiling.

Solution:
- Remove the ')'.