### PR TITLE
Fix glfwGetVideoMode binding; limited GLFW fullscreen support

### DIFF
--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -33,7 +33,7 @@ Move windows                  ✓     Unicode handling            ✓
 Fullscreen                    ✓     Scroll event                ✓
 ========================== ======== ======================== ========
 """
-import os, sys
+import os, sys, platform
 from glumpy import gl
 from glumpy.log import log
 from glumpy.app import configuration
@@ -190,7 +190,7 @@ def set_configuration(config):
 class Window(window.Window):
 
     def __init__( self, width=512, height=512, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
+                  decoration=True, fullscreen=False, screen=None, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -199,6 +199,7 @@ class Window(window.Window):
                                      aspect=aspect,
                                      decoration=decoration,
                                      fullscreen=fullscreen,
+                                     screen=screen,
                                      config=config,
                                      context=context,
                                      color=color)
@@ -222,9 +223,14 @@ class Window(window.Window):
             config = configuration.Configuration()
         set_configuration(config)
 
-        monitor = glfw.glfwGetMonitors()[0] if fullscreen else None
-        self._native_window = glfw.glfwCreateWindow( self._width, self._height,
-                                                     self._title, monitor, None)
+        monitor = glfw.glfwGetMonitors()[self._screen] if fullscreen else None
+        if fullscreen:
+            mode = glfw.glfwGetVideoMode(monitor)
+            self._width, self._height = mode[:2]
+
+        self._native_window = glfw.glfwCreateWindow(self._width, self._height,
+                                                    self._title, monitor, None)
+
 
         if not self._native_window:
             log.critical("Window creation failed")
@@ -238,7 +244,7 @@ class Window(window.Window):
         #      can be different so we try to correct window size such as having
         #      the framebuffer size of the right size
         w,h = glfw.glfwGetFramebufferSize(self._native_window)
-        if w != width or h!= height:
+        if platform == 'darwin' and (w!= width or h!= height):
             width, height  = width//2, height//2
             glfw.glfwSetWindowSize(self._native_window, width, height)
             log.info("HiDPI detected, fixing window size")
@@ -366,10 +372,20 @@ class Window(window.Window):
     def destroy(self):
         glfw.glfwDestroyWindow(self._native_window)
 
-
     def get_screen(self):
-        
-        glfw.glfwGetWindowMonitor()
+        return glfw.glfwGetWindowMonitor(self._native_window)
+
+    def set_fullscreen(self, fullscreen, screen=None):
+        screen = 0 if screen is None else screen
+        mode = glfw.glfwGetVideoMode(glfw.glfwGetMonitors()[screen])
+
+        if fullscreen:
+            glfw.glfwSetWindowMonitor(self._native_window, screen, 0, 0, mode[0], mode[1], mode[-1])
+        else:
+            glfw.glfwSetWindowMonitor(self._native_window, screen, 0, 0, 256, 256, mode[-1])
+
+    def get_fullscreen(self):
+        return self._fullscreen
 
     def set_title(self, title):
         glfw.glfwSetWindowTitle( self._native_window, title)

--- a/glumpy/app/window/backends/backend_qt5.py
+++ b/glumpy/app/window/backends/backend_qt5.py
@@ -201,7 +201,7 @@ def set_configuration(config):
 # ------------------------------------------------------------------ Window ---
 class Window(window.Window):
     def __init__( self, width=256, height=256, title=None, visible=True, aspect=None,
-                  decoration=True, fullscreen=False, config=None, context=None, color=(0,0,0,1), vsync=False):
+                  decoration=True, fullscreen=False, screen=None, config=None, context=None, color=(0,0,0,1), vsync=False):
 
         window.Window.__init__(self, width=width,
                                      height=height,
@@ -210,6 +210,7 @@ class Window(window.Window):
                                      aspect=aspect,
                                      decoration=decoration,
                                      fullscreen=fullscreen,
+                                     screen=screen,
                                      config=config,
                                      context=context,
                                      color=color)
@@ -235,6 +236,8 @@ class Window(window.Window):
         self._native_window.setAutoBufferSwap(False)
         self._native_window.setMouseTracking(True)
         self._native_window.setWindowTitle(self._title)
+
+        self.set_fullscreen(fullscreen, screen)
 
         def paint_gl():
             self.dispatch_event("on_draw", 0.0)

--- a/glumpy/app/window/window.py
+++ b/glumpy/app/window/window.py
@@ -145,7 +145,7 @@ class Window(event.EventDispatcher):
         self._height = height
         self._title = (title or sys.argv[0])
         self._visible = visible
-        self._screen = screen
+        self._screen = 0 if screen is None else screen
         self._fullscreen = fullscreen
         self._decoration = decoration
         self._clock = None

--- a/glumpy/ext/glfw.py
+++ b/glumpy/ext/glfw.py
@@ -541,6 +541,7 @@ glfwIconifyWindow              = _glfw.glfwIconifyWindow
 glfwRestoreWindow              = _glfw.glfwRestoreWindow
 glfwShowWindow                 = _glfw.glfwShowWindow
 glfwHideWindow                 = _glfw.glfwHideWindow
+glfwSetWindowMonitor           = _glfw.glfwSetWindowMonitor
 glfwGetWindowMonitor           = _glfw.glfwGetWindowMonitor
 glfwGetWindowAttrib            = _glfw.glfwGetWindowAttrib
 glfwSetWindowUserPointer       = _glfw.glfwSetWindowUserPointer
@@ -705,13 +706,13 @@ def glfwGetMonitorPhysicalSize(monitor):
 
 def glfwGetVideoMode(monitor):
     _glfw.glfwGetVideoMode.restype = POINTER(GLFWvidmode)
-    c_modes = _glfw.glfwGetVideoModes(monitor)
-    return (c_modes.width,
-            c_modes.height,
-            c_modes.redBits,
-            c_modes.blueBits,
-            c_modes.greenBits,
-            c_modes.refreshRate )
+    c_mode = _glfw.glfwGetVideoMode(monitor)
+    return (c_mode.contents.width,
+            c_mode.contents.height,
+            c_mode.contents.redBits,
+            c_mode.contents.blueBits,
+            c_mode.contents.greenBits,
+            c_mode.contents.refreshRate)
 
 
 def GetGammaRamp(monitor):


### PR DESCRIPTION
Follow-up of https://github.com/glumpy/glumpy/pull/226

* Fix glfwGetVideoMode: previously wrongly called _glfw.glfwGetVideoModes

Adds limited fullscreen support for glfw:
* real fullscreen mode is only possible upon creation of window in glfw; fullscreen will be opened on the monitor specified by screen kwarg
* set_fullscreen can only be used to toggle a windowed fullscreen mode; but so far it only works for the primary screen (index 0), because glfw throws an Accesss Violation when trying to call glfwSetWindowMonitor for any secondary screens;