### PR TITLE
Fixes to window get_title & set_title

### DIFF
--- a/glumpy/app/window/backends/backend_freeglut.py
+++ b/glumpy/app/window/backends/backend_freeglut.py
@@ -368,7 +368,7 @@ class Window(window.Window):
         glut.glutSetWindowTitle( title )
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):

--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -393,7 +393,7 @@ class Window(window.Window):
         glfw.glfwSetWindowTitle( self._native_window, title)
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):

--- a/glumpy/app/window/backends/backend_osxglut.py
+++ b/glumpy/app/window/backends/backend_osxglut.py
@@ -367,7 +367,7 @@ class Window(window.Window):
         glut.glutSetWindowTitle( title )
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):

--- a/glumpy/app/window/backends/backend_pyside.py
+++ b/glumpy/app/window/backends/backend_pyside.py
@@ -356,7 +356,7 @@ class Window(window.Window):
         self._native_window.setWindowTitle(self._title)
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):

--- a/glumpy/app/window/backends/backend_pyside2.py
+++ b/glumpy/app/window/backends/backend_pyside2.py
@@ -354,7 +354,7 @@ class Window(window.Window):
         self._native_window.setWindowTitle(self._title)
         self._title = title
 
-    def get_title(self, title):
+    def get_title(self):
         return self._title
 
     def set_size(self, width, height):

--- a/glumpy/app/window/backends/backend_template.py
+++ b/glumpy/app/window/backends/backend_template.py
@@ -142,7 +142,7 @@ class Window(window.Window):
         """ Set window title """
         raise(NotImplemented)
 
-    def get_title(self, title):
+    def get_title(self):
         """ Get window title """
         raise(NotImplemented)
 

--- a/glumpy/ext/glfw.py
+++ b/glumpy/ext/glfw.py
@@ -531,7 +531,7 @@ glfwWindowHint                 = _glfw.glfwWindowHint
 # glfwDestroyWindow              = _glfw.glfwDestroyWindow
 glfwWindowShouldClose          = _glfw.glfwWindowShouldClose
 glfwSetWindowShouldClose       = _glfw.glfwSetWindowShouldClose
-glfwSetWindowTitle             = _glfw.glfwSetWindowTitle
+# glfwSetWindowTitle             = _glfw.glfwSetWindowTitle
 # glfwGetWindowPos              = _glfw.glfwGetWindowPos
 glfwSetWindowPos               = _glfw.glfwSetWindowPos
 # glfwGetWindowSize             = _glfw.glfwGetWindowSize
@@ -611,7 +611,7 @@ def glfwCreateWindow(width=640, height=480, title="GLFW Window",
                      monitor=None, share=None):
     _glfw.glfwCreateWindow.restype = POINTER(GLFWwindow)
     if not isinstance(title,bytes):
-        title = title.encode("ascii")
+        title = title.encode('utf-8')
     window = _glfw.glfwCreateWindow(width,height,title,monitor,share)
     __windows__.append(window)
     __destroyed__.append(False)
@@ -644,6 +644,12 @@ def glfwDestroyWindow(window):
         del __py_callbacks__[index]
         # del __windows__[index]
     __destroyed__[index] = True
+
+
+def glfwSetWindowTitle(window, title):
+    if not isinstance(title, bytes):
+        title = title.encode('utf-8')
+    _glfw.glfwSetWindowTitle(window, title)
 
 
 def glfwGetWindowPos(window):


### PR DESCRIPTION
Fixed get_title window method for all backends.

Fixed glfw set_title only working with bytes object, now set_title works with str input (same approach as it was already being done done in glfwCreateWindow).

also changed glfwCreateWindow title encoding from 'ascii' to 'utf-8' to support more characters, and because glfwCreateWindow and glfwSetWindowTitle take an encoded utf-8 input anyway (https://www.glfw.org/docs/3.3/group__window.html).