### PR TITLE
Fix math of quadric filter function

### DIFF
--- a/glumpy/library/build-spatial-filters.py
+++ b/glumpy/library/build-spatial-filters.py
@@ -274,7 +274,7 @@ class Quadric(SpatialFilter):
         SpatialFilter.__init__(self, radius=1.5)
 
     def weight(self, x):
-        if x <  0.75:
+        if x <  0.5:
             return 0.75 - x * x
         elif x <  1.5:
             t = x - 1.5


### PR DESCRIPTION
The comment above it clearly indicates that this constant should be 0.5,
not 0.75. The use of 0.75 in its place seems to have been a simple
mistake, perhaps due to the 0.75 constant after it. The corrected value
of 0.5 matches the implementation in AGG, ImageMagick, and elsewhere.

cf. https://sourceforge.net/p/agg/svn/HEAD/tree/agg-2.4/include/agg_image_filters.h
cf. https://github.com/ImageMagick/ImageMagick/blob/main/MagickCore/resize.c#L415