### PR TITLE
Fix deprecated Python 2 attribute naming

### DIFF
--- a/glumpy/app/window/event.py
+++ b/glumpy/app/window/event.py
@@ -438,9 +438,9 @@ class EventDispatcher(object):
         if n_handler_args != n_args:
             if inspect.isfunction(handler) or inspect.ismethod(handler):
                 descr = '%s at %s:%d' % (
-                    handler.func_name,
-                    handler.func_code.co_filename,
-                    handler.func_code.co_firstlineno)
+                    handler.__name__,
+                    handler.__code__.co_filename,
+                    handler.__code__.co_firstlineno)
             else:
                 descr = repr(handler)
 


### PR DESCRIPTION
`func_name` and `func_code` have been renamed to `__name__` and `__code__` in Python 3