### PR TITLE
Bugfix issue #287

### DIFF
--- a/glumpy/gloo/variable.py
+++ b/glumpy/gloo/variable.py
@@ -218,7 +218,8 @@ class Uniform(Variable):
                 self._data = data
 
             elif isinstance(self._data, Texture1D):
-                self._data.set_data(data)
+                #self._data.set_data(data)
+                self._data[...] = data.reshape(self._data.shape)
 
             # Automatic texture creation if required
             else:


### PR DESCRIPTION
When assigning a numpy 1d array to a uniform variable, everything goes fine on the first time, but a bug happens on the second assignment. This PR fixes that issue.