### PR TITLE
add imgui sdl2 backend demo

### DIFF
--- a/examples/imgui_sdl2_demo.py
+++ b/examples/imgui_sdl2_demo.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from glumpy import app
+
+import OpenGL.GL as gl
+
+from sdl2 import *
+
+import imgui
+from imgui.integrations.sdl2 import SDL2Renderer
+
+# Download https://raw.githubusercontent.com/pyimgui/pyimgui/master/doc/examples/testwindow.py put in same directory uncomment line 13 and 32
+#from testwindow import show_test_window
+
+config = app.configuration.Configuration()
+config.profile = "core"
+config.major_version = 4
+config.minor_version = 1
+app.use("sdl2")
+
+
+window = app.Window(width=800, height=800, color=(1,1,1,1), title=b"Imgui_Sdl2_Demo", config=config)
+
+imgui.create_context() 
+imguiRenderer = SDL2Renderer(window._native_window) 
+
+@window.event
+def on_draw(dt):
+
+    imgui.new_frame()
+
+    #show_test_window()
+
+    imgui.begin("Custom window", True)
+    imgui.text("Bar")
+    imgui.text_colored("Eggs", 0.2, 1., 0.)
+    imgui.end()
+    gl.glClearColor(1., 1., 1., 1)
+    gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+    imgui.render()
+    imguiRenderer.render(imgui.get_draw_data())
+
+app.run()


### PR DESCRIPTION
Since imgui_demo doesn't work on macos, I wrote a demo of pyimgui on the sdl2 backend and share with it.

Test on MacOS 12.2.1 X86_64 and MacOS 12.6 apple slicon
<img width="800" alt="截屏2022-10-02 下午3 25 38" src="https://user-images.githubusercontent.com/13301734/193442976-56c7f9d9-32d3-4b10-803b-95094e71e141.png">
