### PR TITLE
remove duplicated draw call

### DIFF
--- a/glumpy/app/movie.py
+++ b/glumpy/app/movie.py
@@ -35,10 +35,12 @@ def record(window, filename, fps):
     # Modify the on_draw event handler to also write a
     # movie frame every time it is called
     old_on_draw = window.get_handler('on_draw')
-    @window.event
+    window.remove_handler('on_draw', old_on_draw)
+    
     def on_draw(dt):
         old_on_draw(dt)
-        write_frame(writer)
+        write_frame(writer)    
+    window.set_handler('on_draw', on_draw)
 
     yield
 


### PR DESCRIPTION
Currently record does not replace the handler properly when something other handler is attached (i.e. a transform), instead just add one more on top on the original draw call. 
So it would actually make the call the original on_draw twice, making it really slow. 
This PR simply remove the original handler and reapply the new one. 
A minimal code to reproduce the issue

```
# -----------------------------------------------------------------------------
# Copyright (c) 2009-2016 Nicolas P. Rougier. All rights reserved.
# Distributed under the (new) BSD License.
# -----------------------------------------------------------------------------
import numpy as np
from glumpy import app, gl, glm, gloo, data
from glumpy.geometry import primitives
from glumpy.app.movie import record
from glumpy.transforms import Trackball, Position

vertex = """
uniform mat4 model, view, projection;
attribute vec3 position;
attribute vec2 texcoord;
varying vec2 v_texcoord;
void main()
{
    gl_Position = <transform>;
    v_texcoord = texcoord;
}
"""

fragment = """
uniform sampler2D texture;
varying vec2 v_texcoord;
void main()
{
    float r = texture2D(texture, v_texcoord).r;
    gl_FragColor = vec4(vec3(r),1.0);
}
"""


width, height = 512,512
window = app.Window(width, height, color=(0.30, 0.30, 0.35, 1.00))

n_frames = 0
@window.event
def on_draw(dt):
    global phi, theta, n_frames
    window.clear()
    gl.glEnable(gl.GL_DEPTH_TEST)
    cube.draw(gl.GL_TRIANGLES, faces)

    # Make cube rotate
    theta += 0.5 # degrees
    phi += 0.5 # degrees
    model = np.eye(4, dtype=np.float32)
    glm.rotate(model, theta, 0, 0, 1)
    glm.rotate(model, phi, 0, 1, 0)
    cube['model'] = model
    n_frames += 1
    print(n_frames)


@window.event
def on_resize(width, height):
    cube['projection'] = glm.perspective(45.0, width / float(height), 2.0, 100.0)

trackball = Trackball(Position("position"), theta=1.0,
                          phi=1.0, zoom=6.0, distance=20.0)
vertices, faces = primitives.cube()
cube = gloo.Program(vertex, fragment)
cube.bind(vertices)
cube['transform'] = trackball

view = np.eye(4, dtype=np.float32)
glm.translate(view, 0, 0, -3)
cube['view'] = view
cube['model'] = np.eye(4, dtype=np.float32)
cube['texture'] = data.checkerboard()
phi, theta = 0, 0

duration = 5.0
framerate = 60
window.attach(cube['transform'])
framecount = 10
print(f'Target frame count: {framecount}')
with record(window, "cube.mp4", fps=framerate):
    app.run(framerate=framerate, framecount=framecount)
print(f'Total draw call: {n_frames}')
```