### PR TITLE
Fix set_fullscreen glfw backend

### DIFF
--- a/glumpy/app/window/backends/backend_glfw.py
+++ b/glumpy/app/window/backends/backend_glfw.py
@@ -378,12 +378,18 @@ class Window(window.Window):
 
     def set_fullscreen(self, fullscreen, screen=None):
         screen = 0 if screen is None else screen
-        mode = glfw.glfwGetVideoMode(glfw.glfwGetMonitors()[screen])
+        monitor = glfw.glfwGetMonitors()[screen]
+        mode = glfw.glfwGetVideoMode(monitor)
 
         if fullscreen:
-            glfw.glfwSetWindowMonitor(self._native_window, screen, 0, 0, mode[0], mode[1], mode[-1])
+            glfw.glfwSetWindowMonitor(
+                self._native_window, monitor, 0, 0,
+                mode.size.width, mode.size.height, mode.refresh_rate
+            )
+            self._fullscreen = True
         else:
-            glfw.glfwSetWindowMonitor(self._native_window, screen, 0, 0, 256, 256, mode[-1])
+            glfw.glfwSetWindowMonitor(self._native_window, None, 0, 0, 256, 256, mode.refresh_rate)
+            self._fullscreen = False
 
     def get_fullscreen(self):
         return self._fullscreen


### PR DESCRIPTION
Hello !

Here a fix for set_fullscreen method of the glfw backend.

It crashed because :
- the monitor parameter should be a Monitor and not an int
- the structure of the "mode" object, returned by glfwGetVideoMode, doesn't match

Also fixing :
- To come back to windowed mode, monitor must be set to None.
- self._fullscreen wasn't updated accordingly

Feel free to ask any questions to clarify,

Best,
Fabien,