### PR TITLE
Fix error handling by removing redundant Py_DECREF

### DIFF
--- a/glumpy/ext/sdf/_sdf.c
+++ b/glumpy/ext/sdf/_sdf.c
@@ -8288,7 +8288,6 @@ __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
         PyList_SET_ITEM(fromlist, 0, marker);
 #else
         if (unlikely(PyList_SetItem(fromlist, 0, marker) < 0)) {
-            Py_DECREF(marker);
             Py_DECREF(fromlist);
             return NULL;
         }


### PR DESCRIPTION
Remove unnecessary Py_DECREF for marker in error handling.

https://github.com/glumpy/glumpy/issues/326